### PR TITLE
Expose Cognito user pool details via SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ The configured deployment parameters above will be accessible by using the follo
 * Secrets - `{{resolve:ssm:/readysetcloud/secrets}}`
 * Sending an HTTP API Request - `{{resolve:ssm:/readysetcloud/send-api-request}}`
 * Querying OpenAI - `{{resolve:ssm:/readysetcloud/ask-openai}}`
+* Cognito User Pool ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-id}}`
+* Cognito User Pool ARN - `{{resolve:ssm:/readysetcloud/auth/user-pool-arn}}`
+* Cognito User Pool Client ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-client-id}}`

--- a/template.yaml
+++ b/template.yaml
@@ -505,6 +505,30 @@ Resources:
         - ALLOW_USER_SRP_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH
 
+  CognitoUserPoolIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/auth/user-pool-id
+      Type: String
+      Value: !Ref CognitoUserPool
+      Description: Cognito user pool ID for cross-service authorizer references
+
+  CognitoUserPoolArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/auth/user-pool-arn
+      Type: String
+      Value: !GetAtt CognitoUserPool.Arn
+      Description: Cognito user pool ARN for cross-service authorizer references
+
+  CognitoUserPoolClientIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/auth/user-pool-client-id
+      Type: String
+      Value: !Ref CognitoUserPoolClient
+      Description: Cognito user pool client ID for cross-service token issuance
+
   CognitoIdentityPool:
     Type: AWS::Cognito::IdentityPool
     Properties:


### PR DESCRIPTION
## Summary
Publishes three SSM parameters under \`/readysetcloud/auth/*\` so downstream stacks can wire \`RSCUserPool\` into their API Gateway authorizers without cross-stack \`Export\` coupling. Matches the existing \`/readysetcloud/*\` config-distribution convention used for the bucket name, cache name, Amplify app id, etc.

- \`/readysetcloud/auth/user-pool-id\` → \`!Ref CognitoUserPool\`
- \`/readysetcloud/auth/user-pool-arn\` → \`!GetAtt CognitoUserPool.Arn\`
- \`/readysetcloud/auth/user-pool-client-id\` → \`!Ref CognitoUserPoolClient\`

README updated with the resolve strings alongside the other global params.

## First consumer
[allenheltondev/content-tracking#15](https://github.com/allenheltondev/content-tracking/issues/15) — switching content-tracking's REST API from API-key auth to a Cognito authorizer backed by this pool. newsletter-service will follow on the same pattern later.

## Test plan
- [ ] \`sam deploy\` to the rsc-core sandbox/dev environment succeeds (3 new SSM resources created)
- [ ] \`aws ssm get-parameter --name /readysetcloud/auth/user-pool-arn\` returns the expected ARN
- [ ] Content-tracking's follow-up PR can resolve all three at deploy time

Closes #175