### PR TITLE
Add @readysetcloud/ui shared design system package

### DIFF
--- a/.github/workflows/bump-ui-version.yaml
+++ b/.github/workflows/bump-ui-version.yaml
@@ -1,0 +1,58 @@
+name: Bump UI Package Version
+
+# When a PR changes anything under ui/, bump the package patch version once.
+# "Once" works by comparing versions against the base branch: if the PR's
+# version already differs from main's (auto-bumped earlier, or a deliberate
+# manual minor/major bump), nothing happens.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ui/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bump-ui-${{ github.head_ref }}
+
+jobs:
+  bump:
+    name: Bump version once per PR
+    runs-on: ubuntu-latest
+    # same-repo PRs only (forks can't be pushed to), and let dependabot
+    # PRs manage themselves
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Bump patch version if the PR hasn't bumped yet
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:ui/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || echo "none")
+          HEAD_VERSION=$(node -p "require('./ui/package.json').version")
+
+          if [ "$BASE_VERSION" = "none" ]; then
+            echo "ui/package.json doesn't exist on ${{ github.base_ref }} yet — keeping the PR's chosen version ($HEAD_VERSION)"
+            exit 0
+          fi
+
+          if [ "$BASE_VERSION" != "$HEAD_VERSION" ]; then
+            echo "Version already bumped this PR ($BASE_VERSION -> $HEAD_VERSION) — skipping"
+            exit 0
+          fi
+
+          cd ui
+          npm version patch --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          cd ..
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump @readysetcloud/ui to $NEW_VERSION"
+          git push
+          echo "Bumped @readysetcloud/ui $BASE_VERSION -> $NEW_VERSION"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,12 @@ jobs:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --parameter-overrides UpdateGitHubSourceCode=true DefaultCacheName=readysetcloud BucketName=readysetcloud AmplifyAppId=${{ secrets.PROD_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }} RootDomainName=readysetcloud.io HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
 
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish UI hosted assets
         run: |
           cd ui
@@ -54,3 +60,16 @@ jobs:
           npm run build
           cd ..
           node scripts/publish-ui-assets.mjs --bucket readysetcloud
+
+      - name: Publish @readysetcloud/ui to npm
+        working-directory: ui
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@readysetcloud/ui@$VERSION" version > /dev/null 2>&1; then
+            echo "@readysetcloud/ui@$VERSION already on npm — skipping publish"
+          else
+            npm publish
+            echo "Published @readysetcloud/ui@$VERSION"
+          fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,3 +45,12 @@ jobs:
           --no-fail-on-empty-changeset \
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --parameter-overrides UpdateGitHubSourceCode=true DefaultCacheName=readysetcloud BucketName=readysetcloud AmplifyAppId=${{ secrets.PROD_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }} RootDomainName=readysetcloud.io HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
+
+      - name: Publish UI hosted assets
+        run: |
+          cd ui
+          npm ci
+          npm test
+          npm run build
+          cd ..
+          node scripts/publish-ui-assets.mjs --bucket readysetcloud

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -48,6 +48,15 @@ jobs:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
 
+      - name: Publish UI hosted assets
+        run: |
+          cd ui
+          npm ci
+          npm test
+          npm run build
+          cd ..
+          node scripts/publish-ui-assets.mjs --bucket readysetcloud-stage
+
   deploy-dependabot:
     name: Deploy Dependabot Updates
     if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,6 @@ export default [
       }
     }
   },
-  { ignores: ['.aws-sam/*'] },
+  { ignores: ['.aws-sam/*', 'ui/dist/*', 'ui/node_modules/*', 'ui/tailwind-preset.cjs'] },
   pluginJs.configs.recommended
 ];

--- a/scripts/publish-ui-assets.mjs
+++ b/scripts/publish-ui-assets.mjs
@@ -1,0 +1,74 @@
+/*
+ * Publishes the @readysetcloud/ui hosted assets to the assets bucket so any
+ * surface can consume the brand with a <link>/<script> tag (same model as
+ * Amplify's hosted UI assets):
+ *
+ *   https://<assets-host>/ui/<version>/styles/index.css
+ *   https://<assets-host>/ui/<version>/auth.global.js   (window.rscAuth)
+ *   https://<assets-host>/ui/latest/...                 (short cache)
+ *
+ * Versioned paths are immutable (1y cache); latest/ is a 5-minute pointer.
+ * Public read comes from the PublicReadUiAssets bucket policy statement.
+ *
+ * Usage: node scripts/publish-ui-assets.mjs --bucket <name>
+ * Run `npm run build` in ui/ first (dist/browser must exist).
+ */
+
+import { readFile, readdir } from 'fs/promises';
+import { join, extname } from 'path';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const s3 = new S3Client();
+
+const CONTENT_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.map': 'application/json'
+};
+
+const args = process.argv.slice(2);
+const bucket = args[args.indexOf('--bucket') + 1];
+if (!bucket || bucket.startsWith('--')) {
+  console.error('Usage: node scripts/publish-ui-assets.mjs --bucket <name>');
+  process.exit(1);
+}
+
+const { version } = JSON.parse(await readFile('ui/package.json', 'utf8'));
+
+const uploads = [];
+for (const [dir, prefix] of [
+  ['ui/styles', 'styles'],
+  ['ui/dist/browser', '']
+]) {
+  for (const file of await readdir(dir)) {
+    const ext = extname(file);
+    if (!CONTENT_TYPES[ext]) continue;
+    uploads.push({ path: join(dir, file), key: prefix ? `${prefix}/${file}` : file, ext });
+  }
+}
+
+if (!uploads.some((u) => u.key === 'auth.global.js')) {
+  console.error('ui/dist/browser is missing — run `npm run build` in ui/ first.');
+  process.exit(1);
+}
+
+for (const { path, key, ext } of uploads) {
+  const body = await readFile(path);
+  for (const [root, cacheControl] of [
+    [`ui/${version}`, 'public, max-age=31536000, immutable'],
+    ['ui/latest', 'public, max-age=300']
+  ]) {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: `${root}/${key}`,
+        Body: body,
+        ContentType: CONTENT_TYPES[ext],
+        CacheControl: cacheControl
+      })
+    );
+    console.log(`uploaded s3://${bucket}/${root}/${key}`);
+  }
+}
+
+console.log(`\nPublished @readysetcloud/ui ${version} hosted assets to ${bucket}.`);

--- a/template.yaml
+++ b/template.yaml
@@ -572,6 +572,11 @@ Resources:
             Principal: '*'
             Action: s3:GetObject
             Resource: !Sub 'arn:${AWS::Partition}:s3:::${BucketName}/*.webp'
+          - Sid: PublicReadUiAssets
+            Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub 'arn:${AWS::Partition}:s3:::${BucketName}/ui/*'
 
   ImageResizing:
     Type: AWS::Serverless::Application

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,156 @@
+# @readysetcloud/ui — Agent Guide
+
+Instructions for AI agents (and humans) consuming or migrating apps onto the shared Ready, Set, Cloud design system. This is the complete API surface and the rules that keep the three surfaces converged.
+
+## What this package is
+
+The single source of truth for brand, components, and auth across:
+
+| Surface | Repo | Consumes via |
+| --- | --- | --- |
+| Newsletter dashboard | `readysetcloud/newsletter-service` → `dashboard-ui/` | npm |
+| Concurrency bootcamp platform | `concurrency-bootcamp` → `platform/` | npm |
+| Bootcamp course pages (vanilla JS) | `concurrency-bootcamp` → `js/` | hosted `auth.global.js` |
+| readysetcloud.io (Hugo) | `readysetcloud/ready-set-cloud` | hosted `styles/*.css` |
+
+Source lives in `rsc-core/ui`. **Never fork or copy this code into an app — change it here, version it, consume it.**
+
+## Hard rules (violating these defeats the package's purpose)
+
+1. **Never hardcode brand colors** in an app. Use token variables (`rgb(var(--primary-600))`), the Tailwind preset scales (`bg-primary-600`), or the shipped classes (`.btn-primary`).
+2. **Raleway is the wordmark face only.** It exists as `--font-logo` for text-rendered logo lockups. Never set UI text in Raleway. Headings = Sora (`--font-display`), body = Manrope (`--font-sans`), data/code = JetBrains Mono (`--font-mono`).
+3. **Don't re-implement components that exist here.** If an app needs a variant, add it to this package first.
+4. **Respect the responsive contract.** Components ship with 44px touch targets, ≥16px mobile inputs, fluid type, and safe-area handling. Don't override these down.
+5. **Don't change the `rsc:auth` session contract** (`{idToken, refreshToken, expiresAt}` in localStorage under key `rsc:auth`). The vanilla course pages and the platform share sessions through it. Change it only deliberately, on both sides, in this package.
+6. **Dark mode** is system-preference by default with `<html data-theme="dark|light">` override. Never implement a separate theming mechanism.
+
+## Install (React apps)
+
+```bash
+npm install @readysetcloud/ui        # public npm
+```
+
+```ts
+// main.tsx — ALWAYS import the stylesheet once, before app styles
+import '@readysetcloud/ui/styles.css';
+// only if the app doesn't already load brand fonts in index.html:
+import '@readysetcloud/ui/fonts.css';
+```
+
+```js
+// tailwind.config.js
+module.exports = {
+  presets: [require('@readysetcloud/ui/tailwind-preset')],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    './node_modules/@readysetcloud/ui/dist/**/*.js'  // REQUIRED — components use token classes
+  ]
+};
+```
+
+The preset aliases `blue`→primary, `green`/`teal`→success, `red`/`rose`→error, `orange`/`amber`/`yellow`→warning, `gray`/`slate`→secondary, so existing utility classes stay on-brand during migration without a rename sweep.
+
+## Components — `import { ... } from '@readysetcloud/ui'`
+
+All components are typed, accept `className`, and forward standard HTML props.
+
+| Component | Key props | Notes |
+| --- | --- | --- |
+| `Button` | `variant: 'primary'\|'secondary'\|'success'\|'warning'\|'error'\|'ghost'`, `size: 'sm'\|'md'\|'lg'`, `block`, `loading`, `loadingLabel` | `loading` disables + spinner + optional label swap. Default `type="button"`. |
+| `Input` | `label` (required), `error`, `hint` + all input props | Label/aria wiring automatic. `error` renders red border + `role="alert"` message. |
+| `PasswordInput` | same as Input, no `type` | Show/hide toggle built in. |
+| `CodeInput` | `label?`, `error`, `length` (default 6) | Numeric, `autoComplete="one-time-code"`, monospace centered. |
+| `TextArea` / `Select` | `label`, `error`, `hint` | Same Field wiring. Select takes `<option>` children. |
+| `Field` | `label`, `error`, `hint`, `children: (props) => ReactNode` | Render-prop for wiring custom controls. |
+| `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardBody`, `CardFooter` | div props | Compound card. |
+| `Badge` | `variant: 'primary'\|'success'\|'warning'\|'error'\|'neutral'` | Status pill (uppercase mono). |
+| `Alert` | `variant: 'error'\|'success'\|'info'` | `role="alert"` for errors. |
+| `Modal` | `open`, `onClose`, `aria-label` | Native `<dialog>`: Esc/backdrop close, focus trap free. Bottom sheet on ≤640px. |
+| `ToastProvider` / `useToast()` | `toast(message, { variant?, duration? })` | Mount provider once at app root. Errors default to 8s, others 5s. |
+| `Spinner` | span props | Inherits `currentColor`. |
+| `Skeleton` | `width`, `height` | Shimmer placeholder. |
+| `EmptyState` | `title`, `description?`, `icon?`, `action?` | |
+| `Container` | div props | max 72rem, fluid padding. |
+| `cx(...parts)` | | Classname join helper (replaces clsx for simple cases). |
+
+## Auth — `import { ... } from '@readysetcloud/ui/auth'`
+
+One Cognito user pool for all apps (rsc-core SSM: `/readysetcloud/auth/user-pool-id`, `.../user-pool-client-id`); each app brings its own app client id.
+
+**Setup (required before any auth call):**
+```ts
+configureAuth({ region: 'us-east-1', clientId: '<app client id>' });
+// or an async loader:
+configureAuth(async () => (await fetch('/auth-config.json')).json());
+```
+
+**React:**
+```tsx
+<AuthProvider>...</AuthProvider>                    // mount once at root
+const { signedIn, user, getToken, signOut } = useAuth();
+<RequireAuth fallback={<Navigate to="/login" />}>   // router-agnostic guard
+```
+- `user` = decoded id-token claims (`email`, `given_name`, `family_name`, `sub`, plus custom claims)
+- `getToken()` returns a valid id token, auto-refreshing 60s before expiry — use for `Authorization: Bearer` headers
+- Cross-tab sign-in/out sync is automatic (storage events)
+
+**Prebuilt flows** (each renders a complete `AuthCard`; pass your router's links):
+```tsx
+<LoginForm onSuccess={} onNeedsConfirmation={(email)=>} logo={} forgotPasswordLink={} signUpPrompt={} />
+<SignUpForm onSuccess={} logo={} signInPrompt={} initialConfirmEmail={} />
+<ForgotPasswordForm onSuccess={} logo={} signInLink={} />
+```
+Flow behaviors already handled: NEW_PASSWORD_REQUIRED challenge, unconfirmed-account → resend + confirm step, 6-digit code entry with 60s resend cooldown, friendly Cognito error copy.
+
+**Core functions** (framework-agnostic, all promise-based): `signIn`, `signUp(firstName, lastName, email, password)` — the pool REQUIRES given/family name — `confirmSignUp`, `resendConfirmationCode`, `forgotPassword`, `confirmForgotPassword`, `respondNewPassword`, `getFreshIdToken`, `signOut`, `readSession`, `isSignedIn`, `claims`, `onAuthChange`.
+
+**Validation** (matches the ACTUAL pool policy — 8+ chars, upper, lower, number, **symbols NOT required**): `validateEmail`, `validatePassword`, `validateName`, `validateCode`, `PASSWORD_REQUIREMENTS`.
+
+## Non-React consumers (hosted assets)
+
+Published to the assets bucket on every rsc-core deploy:
+
+```html
+<link rel="stylesheet" href="https://<assets-host>/ui/<version>/styles/index.css">
+<script src="https://<assets-host>/ui/<version>/auth.global.js"></script>
+<script>
+  rscAuth.configureAuth({ region: 'us-east-1', clientId: '...' });
+</script>
+```
+- `ui/<version>/` is immutable (1y cache); `ui/latest/` is a 5-minute pointer
+- `styles/tokens.css` alone = variables only (for a site keeping its own components but adopting the palette)
+- `auth.global.js` exposes the full core as `window.rscAuth` — same `rsc:auth` contract, so it shares sessions with npm-consuming SPAs on the same origin
+
+## Migration playbooks
+
+### concurrency-bootcamp `platform/` (smallest — its code IS this package's ancestor)
+1. `npm i @readysetcloud/ui`; import `styles.css`; adopt the Tailwind preset; delete the token blocks from `src/index.css` and color/font config from `tailwind.config.js`.
+2. Delete `src/lib/auth.ts`, `src/lib/validate.ts` → import from `@readysetcloud/ui/auth`. Keep `configureAuth(async () => ...)` pointed at `/auth-config.json`.
+3. Replace `src/context/AuthContext.tsx` with the package's `AuthProvider`/`useAuth`/`RequireAuth` (RequireAuth here takes a `fallback` node instead of rendering a redirect itself).
+4. Replace `src/components/forms.tsx` usage: `AuthCard`→`AuthCard`, `Field`→`Input`, `PasswordField`→`PasswordInput`, `CodeField`→`CodeInput`, `FormAlert`→`Alert variant="error"`, `SubmitButton`→`Button type="submit" loading`, `ResendCodeButton`→same name. Or replace whole pages with `LoginForm`/`SignUpForm`/`ForgotPasswordForm`.
+5. Course pages (`js/account.js`): replace its embedded auth logic with the hosted `auth.global.js` when touched — the session contract is identical, so this can be incremental.
+
+### newsletter-service `dashboard-ui/` (biggest win — drops aws-amplify)
+1. Install + styles + preset as above. The shipped `.btn-*`/`.card`/`.input` classes intentionally match the app's existing `@layer components` definitions — delete those layers from `src/index.css`, keep app-specific utilities.
+2. Replace `src/components/ui/*` equivalents (Button, Input, Card, Modal, Toast, Badge, Loading/Skeleton, EmptyState, Container) with package imports; keep app-specific components (charts, analytics, issues) local.
+3. Auth migration OFF amplify: remove `aws-amplify` dep and `src/config/amplify.ts`; rewrite `src/contexts/AuthContext.tsx` on top of `@readysetcloud/ui/auth` (`configureAuth` with the app's client id via env). Derived flags (`isAdmin`, `tenantId`, role checks) come from `claims()`/`useAuth().user` — the same JWT claims amplify was parsing.
+4. NOTE: users stay signed in only if the amplify → `rsc:auth` migration reads the existing Cognito tokens; simplest accepted behavior is a one-time re-login. Flag this in the PR.
+5. Fix the password copy: the app currently claims special characters are required — the pool does not (`RequireSymbols: false`). Use `PASSWORD_REQUIREMENTS`.
+
+### ready-set-cloud (Hugo)
+1. Link `tokens.css` (or full `index.css`) from the hosted assets in `layouts/partials/head.html`.
+2. Map theme SCSS variables to the tokens where practical (`$primary-color: rgb(var(--primary-500))` equivalents). Subtle changes only — this site's look is the brand anchor.
+3. No auth on this site today; if added, use the hosted `auth.global.js`.
+
+## Developing this package
+
+```bash
+cd ui
+npm install
+npm test          # vitest — auth core + validation (20 tests)
+npm run build     # tsup → dist/ (npm ESM+dts) + dist/browser/ (ESM+IIFE)
+npm run typecheck
+```
+
+Checklist for changes: keep class names stable (apps depend on them) · both light AND dark values for any new token · mobile-first (44px targets, ≥16px inputs) · new colors go through the ramp convention (50–950 + dark inversion) · bump `version` in package.json (deploy publishes hosted assets under it; CI publishes to npm when the version is new).

--- a/ui/README.md
+++ b/ui/README.md
@@ -50,14 +50,33 @@ module.exports = {
 
 Every preset color resolves through the token CSS variables, so `bg-primary-600` is always on-brand and dark-mode aware. Semantic aliases (`blue`→primary, `red`→error, `gray`→secondary, …) keep existing utility usage working during migration.
 
-### Non-React consumers (Hugo)
+### Non-React consumers (Hugo, course pages) — hosted assets
 
-The component classes are plain CSS driven by the tokens — no Tailwind, no React needed:
+Every rsc-core deploy publishes the styles and a browser auth bundle to the
+assets bucket (same model as Amplify's hosted UI). Versioned paths are
+immutable; `latest/` is a 5-minute pointer:
+
+```
+ui/<version>/styles/index.css      tokens + base + component classes
+ui/<version>/styles/tokens.css     variables only
+ui/<version>/auth.global.js        IIFE — window.rscAuth (~6KB)
+ui/<version>/auth.js               ESM build of the same core
+ui/latest/...                      short-cache pointer to the newest version
+```
 
 ```html
-<link rel="stylesheet" href=".../styles/index.css">
+<link rel="stylesheet" href="https://<assets-host>/ui/0.1.0/styles/index.css">
 <button class="btn btn-primary">Subscribe</button>
+
+<script src="https://<assets-host>/ui/0.1.0/auth.global.js"></script>
+<script>
+  rscAuth.configureAuth({ region: 'us-east-1', clientId: '...' });
+  if (rscAuth.isSignedIn()) { /* ... */ }
+</script>
 ```
+
+Publishing runs in the deploy workflows via `scripts/publish-ui-assets.mjs`;
+public read comes from the `PublicReadUiAssets` bucket policy statement.
 
 ## Components
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,122 @@
+# @readysetcloud/ui
+
+Shared design tokens, UI components, and Cognito auth for every Ready, Set, Cloud surface — the newsletter dashboard, the concurrency bootcamp platform, and readysetcloud.io.
+
+## The brand, in one place
+
+| Layer | Decision |
+| --- | --- |
+| Primary | `#219EFF` azure — full 50–950 ramp with dark-mode inversion |
+| Semantics | success `#14B8A6` · warning `#F97316` · error `#C81E22` |
+| Type | **Sora** headings · **Manrope** body · **JetBrains Mono** data/code |
+| Wordmark | **Raleway** is the logo face only (`--font-logo`) — never UI text |
+| Shape | 4–6px radius, soft shadows — sharper than the old app look, not square |
+| Responsive | 44px touch targets, fluid `clamp()` type, safe-area insets, ≥16px mobile inputs |
+
+## Install
+
+```bash
+# .npmrc
+@readysetcloud:registry=https://npm.pkg.github.com
+
+npm install @readysetcloud/ui
+```
+
+## Styles
+
+```ts
+// main.tsx — tokens + base + component classes (light & dark)
+import '@readysetcloud/ui/styles.css';
+
+// only if your app doesn't already load the brand fonts:
+import '@readysetcloud/ui/fonts.css';
+```
+
+Dark mode: follows the system by default; force with `<html data-theme="dark">` (same convention the apps already use).
+
+### Tailwind (for your app's own UI)
+
+```js
+// tailwind.config.js
+module.exports = {
+  presets: [require('@readysetcloud/ui/tailwind-preset')],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    './node_modules/@readysetcloud/ui/dist/**/*.js'
+  ]
+};
+```
+
+Every preset color resolves through the token CSS variables, so `bg-primary-600` is always on-brand and dark-mode aware. Semantic aliases (`blue`→primary, `red`→error, `gray`→secondary, …) keep existing utility usage working during migration.
+
+### Non-React consumers (Hugo)
+
+The component classes are plain CSS driven by the tokens — no Tailwind, no React needed:
+
+```html
+<link rel="stylesheet" href=".../styles/index.css">
+<button class="btn btn-primary">Subscribe</button>
+```
+
+## Components
+
+```tsx
+import {
+  Button, Input, PasswordInput, CodeInput, TextArea, Select,
+  Card, CardHeader, CardTitle, CardBody, CardFooter,
+  Badge, Alert, Modal, ToastProvider, useToast,
+  Spinner, Skeleton, EmptyState, Container
+} from '@readysetcloud/ui';
+```
+
+## Auth
+
+One Cognito user pool across all apps (exposed by rsc-core via SSM under `/readysetcloud/auth/*`); each app brings its own app client id.
+
+```tsx
+import { configureAuth, AuthProvider, RequireAuth, useAuth } from '@readysetcloud/ui/auth';
+
+// static config…
+configureAuth({ region: 'us-east-1', clientId: import.meta.env.VITE_COGNITO_CLIENT_ID });
+// …or a runtime loader (how concurrency bootcamp does it)
+configureAuth(async () => (await fetch('/auth-config.json')).json());
+
+<AuthProvider>
+  <Route path="/app" element={
+    <RequireAuth fallback={<Navigate to="/login" />}>
+      <Dashboard />
+    </RequireAuth>
+  } />
+</AuthProvider>;
+
+// in components
+const { signedIn, user, getToken, signOut } = useAuth();
+const res = await fetch(url, { headers: { Authorization: `Bearer ${await getToken()}` } });
+```
+
+Prebuilt flows (router-agnostic — pass your own links):
+
+```tsx
+import { LoginForm, SignUpForm, ForgotPasswordForm } from '@readysetcloud/ui/auth';
+
+<LoginForm
+  onSuccess={() => navigate('/app')}
+  onNeedsConfirmation={(email) => navigate(`/signup?confirm=${email}`)}
+  forgotPasswordLink={<Link className="auth-link" to="/forgot-password">Forgot password?</Link>}
+  signUpPrompt={<>New here? <Link to="/signup">Create an account</Link></>}
+/>
+```
+
+The session contract is the `rsc:auth` localStorage document (`{idToken, refreshToken, expiresAt}`) — identical to what the concurrency bootcamp platform and course pages already share. Sign-in on one surface of an origin is sign-in on all of them; tokens auto-refresh 60s before expiry; offline never signs you out.
+
+> **Cross-subdomain SSO caveat:** localStorage is per-origin. Sharing a session across `*.readysetcloud.io` subdomains requires a parent-domain cookie — a deliberate future change tracked separately.
+
+## Development
+
+```bash
+cd ui
+npm install
+npm test        # vitest — auth core + validation
+npm run build   # tsup → dist/ (ESM + .d.ts)
+```

--- a/ui/README.md
+++ b/ui/README.md
@@ -15,10 +15,9 @@ Shared design tokens, UI components, and Cognito auth for every Ready, Set, Clou
 
 ## Install
 
-```bash
-# .npmrc
-@readysetcloud:registry=https://npm.pkg.github.com
+Published to public npm on every prod deploy (new versions only):
 
+```bash
 npm install @readysetcloud/ui
 ```
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,3232 @@
+{
+  "name": "@readysetcloud/ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@readysetcloud/ui",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "jsdom": "^29.0.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+      "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.7"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+      "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@readysetcloud/ui",
+  "version": "0.1.0",
+  "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/readysetcloud/rsc-core.git",
+    "directory": "ui"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "files": [
+    "dist",
+    "styles",
+    "tailwind-preset.cjs"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./auth": {
+      "types": "./dist/auth/index.d.ts",
+      "import": "./dist/auth/index.js"
+    },
+    "./styles.css": "./styles/index.css",
+    "./tokens.css": "./styles/tokens.css",
+    "./fonts.css": "./styles/fonts.css",
+    "./tailwind-preset": "./tailwind-preset.cjs"
+  },
+  "sideEffects": [
+    "*.css"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "directory": "ui"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "files": [
     "dist",

--- a/ui/src/auth/browser.ts
+++ b/ui/src/auth/browser.ts
@@ -1,0 +1,47 @@
+/*
+ * Browser bundle entry — the framework-agnostic auth core for plain
+ * <script> consumers (course pages, static sites). No React, no deps.
+ *
+ * IIFE build exposes everything as `window.rscAuth`:
+ *
+ *   <script src="https://<assets>/ui/<version>/auth.global.js"></script>
+ *   <script>
+ *     rscAuth.configureAuth({ region: 'us-east-1', clientId: '...' });
+ *     if (rscAuth.isSignedIn()) { ... }
+ *   </script>
+ *
+ * The ESM build (auth.js) serves `import { signIn } from '.../auth.js'`.
+ */
+
+export { configureAuth, getConfig, type AuthConfig } from './config';
+export {
+  AUTH_KEY,
+  AuthError,
+  isAuthError,
+  errorMessage,
+  readSession,
+  isSignedIn,
+  claims,
+  onAuthChange,
+  signIn,
+  signUp,
+  confirmSignUp,
+  resendConfirmationCode,
+  forgotPassword,
+  confirmForgotPassword,
+  respondNewPassword,
+  getFreshIdToken,
+  signOut,
+  type Session,
+  type IdClaims,
+  type SignInResult
+} from './core';
+export {
+  isValidEmail,
+  isValidPassword,
+  validateEmail,
+  validatePassword,
+  validateName,
+  validateCode,
+  PASSWORD_REQUIREMENTS
+} from './validate';

--- a/ui/src/auth/components/AuthCard.tsx
+++ b/ui/src/auth/components/AuthCard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { Card, CardBody } from '../../components/Card';
+
+export interface AuthCardProps {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  /** Brand slot rendered above the title (logo image or lockup). */
+  logo?: ReactNode;
+  children: ReactNode;
+  /** Rendered below the card body, e.g. "New here? Create an account". */
+  footer?: ReactNode;
+}
+
+/** Centered card wrapper shared by every auth flow. */
+export function AuthCard({ title, subtitle, logo, children, footer }: AuthCardProps) {
+  return (
+    <Card className="auth-card">
+      <CardBody>
+        {logo}
+        <div>
+          <h1 className="auth-title">{title}</h1>
+          {subtitle && <p className="auth-subtitle">{subtitle}</p>}
+        </div>
+        {children}
+        {footer && <p className="auth-alt">{footer}</p>}
+      </CardBody>
+    </Card>
+  );
+}

--- a/ui/src/auth/components/ForgotPasswordForm.tsx
+++ b/ui/src/auth/components/ForgotPasswordForm.tsx
@@ -1,0 +1,128 @@
+import { useState, type FormEvent, type ReactNode } from 'react';
+import { Alert } from '../../components/Alert';
+import { Button } from '../../components/Button';
+import { CodeInput, Input, PasswordInput } from '../../components/Input';
+import { confirmForgotPassword, forgotPassword } from '../core';
+import { validateCode, validateEmail, validatePassword } from '../validate';
+import { AuthCard } from './AuthCard';
+import { PasswordRequirements } from './PasswordRequirements';
+
+export interface ForgotPasswordFormProps {
+  /** Called after the password is reset — route to sign-in. */
+  onSuccess: () => void;
+  logo?: ReactNode;
+  /** e.g. <Link to="/login">Back to sign in</Link> */
+  signInLink?: ReactNode;
+}
+
+type Step = 'email' | 'reset';
+
+export function ForgotPasswordForm({ onSuccess, logo, signInLink }: ForgotPasswordFormProps) {
+  const [step, setStep] = useState<Step>('email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{
+    email?: string;
+    code?: string;
+    password?: string;
+  }>({});
+  const [busy, setBusy] = useState(false);
+
+  const submitEmail = async (e: FormEvent) => {
+    e.preventDefault();
+    const emailError = validateEmail(email);
+    setFieldErrors({ email: emailError });
+    if (emailError) return;
+
+    setBusy(true);
+    setError('');
+    try {
+      await forgotPassword(email.trim());
+      setStep('reset');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitReset = async (e: FormEvent) => {
+    e.preventDefault();
+    const errors = {
+      code: validateCode(code),
+      password: validatePassword(newPassword)
+    };
+    setFieldErrors(errors);
+    if (errors.code || errors.password) return;
+
+    setBusy(true);
+    setError('');
+    try {
+      await confirmForgotPassword(email.trim(), code.trim(), newPassword);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (step === 'reset') {
+    return (
+      <AuthCard
+        title="Reset your password"
+        subtitle={`Enter the 6-digit code we sent to ${email.trim()} and choose a new password.`}
+        logo={logo}
+        footer={signInLink}
+      >
+        <form onSubmit={submitReset} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {error && <Alert variant="error">{error}</Alert>}
+          <CodeInput
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            error={fieldErrors.code}
+            autoFocus
+          />
+          <PasswordInput
+            label="New password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            error={fieldErrors.password}
+            autoComplete="new-password"
+          />
+          <PasswordRequirements />
+          <Button type="submit" block loading={busy} loadingLabel="Resetting…">
+            Reset password
+          </Button>
+        </form>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title="Forgot your password?"
+      subtitle="Enter your email and we'll send you a reset code."
+      logo={logo}
+      footer={signInLink}
+    >
+      <form onSubmit={submitEmail} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {error && <Alert variant="error">{error}</Alert>}
+        <Input
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={fieldErrors.email}
+          autoComplete="email"
+          autoFocus
+        />
+        <Button type="submit" block loading={busy} loadingLabel="Sending…">
+          Send reset code
+        </Button>
+      </form>
+    </AuthCard>
+  );
+}

--- a/ui/src/auth/components/LoginForm.tsx
+++ b/ui/src/auth/components/LoginForm.tsx
@@ -1,0 +1,148 @@
+import { useState, type FormEvent, type ReactNode } from 'react';
+import { Alert } from '../../components/Alert';
+import { Button } from '../../components/Button';
+import { Input, PasswordInput } from '../../components/Input';
+import { isAuthError, respondNewPassword, signIn } from '../core';
+import { validateEmail, validatePassword } from '../validate';
+import { AuthCard } from './AuthCard';
+import { PasswordRequirements } from './PasswordRequirements';
+
+export interface LoginFormProps {
+  /** Called after a successful sign-in (session already saved). */
+  onSuccess: () => void;
+  /**
+   * Called when the account still needs email verification —
+   * route to your confirm/sign-up screen (a fresh code is already sent).
+   */
+  onNeedsConfirmation?: (email: string) => void;
+  /** Brand slot above the title. */
+  logo?: ReactNode;
+  /** e.g. <Link to="/forgot-password">Forgot password?</Link> */
+  forgotPasswordLink?: ReactNode;
+  /** e.g. <>New here? <Link to="/signup">Create an account</Link></> */
+  signUpPrompt?: ReactNode;
+}
+
+type Step = { name: 'credentials' } | { name: 'newPassword'; session: string };
+
+export function LoginForm({
+  onSuccess,
+  onNeedsConfirmation,
+  logo,
+  forgotPasswordLink,
+  signUpPrompt
+}: LoginFormProps) {
+  const [step, setStep] = useState<Step>({ name: 'credentials' });
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({});
+  const [busy, setBusy] = useState(false);
+
+  const submitCredentials = async (e: FormEvent) => {
+    e.preventDefault();
+    const errors = { email: validateEmail(email), password: password ? undefined : 'Enter your password.' };
+    setFieldErrors(errors);
+    if (errors.email || errors.password) return;
+
+    setBusy(true);
+    setError('');
+    try {
+      const result = await signIn(email.trim(), password);
+      if (result.kind === 'newPasswordRequired') {
+        setStep({ name: 'newPassword', session: result.session });
+      } else {
+        onSuccess();
+      }
+    } catch (err) {
+      if (isAuthError(err) && err.code === 'UserNotConfirmedException' && onNeedsConfirmation) {
+        onNeedsConfirmation(email.trim());
+        return;
+      }
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitNewPassword = async (e: FormEvent) => {
+    e.preventDefault();
+    if (step.name !== 'newPassword') return;
+    const invalid = validatePassword(newPassword);
+    if (invalid) {
+      setError(invalid);
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      await respondNewPassword(email.trim(), newPassword, step.session);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (step.name === 'newPassword') {
+    return (
+      <AuthCard
+        title="Set a new password"
+        subtitle="Your account requires a new password before signing in."
+        logo={logo}
+      >
+        <form onSubmit={submitNewPassword} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {error && <Alert variant="error">{error}</Alert>}
+          <PasswordInput
+            label="New password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            autoComplete="new-password"
+            autoFocus
+          />
+          <PasswordRequirements />
+          <Button type="submit" block loading={busy} loadingLabel="Saving…">
+            Save and sign in
+          </Button>
+        </form>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title="Sign in"
+      subtitle="One account across every Ready, Set, Cloud app."
+      logo={logo}
+      footer={signUpPrompt}
+    >
+      <form onSubmit={submitCredentials} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {error && <Alert variant="error">{error}</Alert>}
+        <Input
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={fieldErrors.email}
+          autoComplete="email"
+          autoFocus
+        />
+        <PasswordInput
+          label="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={fieldErrors.password}
+          autoComplete="current-password"
+        />
+        {forgotPasswordLink && (
+          <div style={{ textAlign: 'right', fontSize: '0.8125rem' }}>{forgotPasswordLink}</div>
+        )}
+        <Button type="submit" block loading={busy} loadingLabel="Signing in…">
+          Sign in
+        </Button>
+      </form>
+    </AuthCard>
+  );
+}

--- a/ui/src/auth/components/PasswordRequirements.tsx
+++ b/ui/src/auth/components/PasswordRequirements.tsx
@@ -1,0 +1,22 @@
+import { PASSWORD_REQUIREMENTS } from '../validate';
+
+/** The pool's actual password policy, shown under password fields. */
+export function PasswordRequirements() {
+  return (
+    <ul
+      style={{
+        margin: 0,
+        paddingLeft: '1.125rem',
+        fontSize: '0.75rem',
+        color: 'rgb(var(--muted-foreground))',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.125rem'
+      }}
+    >
+      {PASSWORD_REQUIREMENTS.map((req) => (
+        <li key={req}>{req}</li>
+      ))}
+    </ul>
+  );
+}

--- a/ui/src/auth/components/ResendCodeButton.tsx
+++ b/ui/src/auth/components/ResendCodeButton.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+import { resendConfirmationCode } from '../core';
+
+export interface ResendCodeButtonProps {
+  email: string;
+  /** Cooldown between sends, seconds (default 60). */
+  cooldown?: number;
+  onError?: (message: string) => void;
+}
+
+/** "Resend code" text button with a cooldown timer. */
+export function ResendCodeButton({ email, cooldown = 60, onError }: ResendCodeButtonProps) {
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const timer = useRef<number | undefined>(undefined);
+
+  useEffect(() => () => window.clearInterval(timer.current), []);
+
+  const start = () => {
+    setSecondsLeft(cooldown);
+    timer.current = window.setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) window.clearInterval(timer.current);
+        return s - 1;
+      });
+    }, 1000);
+  };
+
+  const resend = async () => {
+    try {
+      await resendConfirmationCode(email);
+      start();
+    } catch (e) {
+      onError?.(e instanceof Error ? e.message : 'Could not resend the code.');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="auth-link"
+      onClick={resend}
+      disabled={secondsLeft > 0}
+      style={{
+        background: 'none',
+        border: 'none',
+        cursor: secondsLeft > 0 ? 'default' : 'pointer',
+        opacity: secondsLeft > 0 ? 0.6 : 1,
+        padding: 0,
+        minHeight: 'auto',
+        fontSize: '0.8125rem'
+      }}
+    >
+      {secondsLeft > 0 ? `Resend code in ${secondsLeft}s` : 'Resend code'}
+    </button>
+  );
+}

--- a/ui/src/auth/components/SignUpForm.tsx
+++ b/ui/src/auth/components/SignUpForm.tsx
@@ -1,0 +1,162 @@
+import { useState, type FormEvent, type ReactNode } from 'react';
+import { Alert } from '../../components/Alert';
+import { Button } from '../../components/Button';
+import { CodeInput, Input, PasswordInput } from '../../components/Input';
+import { confirmSignUp, signIn, signUp } from '../core';
+import { validateCode, validateEmail, validateName, validatePassword } from '../validate';
+import { AuthCard } from './AuthCard';
+import { PasswordRequirements } from './PasswordRequirements';
+import { ResendCodeButton } from './ResendCodeButton';
+
+export interface SignUpFormProps {
+  /** Called once the account is confirmed (and signed in when possible). */
+  onSuccess: () => void;
+  logo?: ReactNode;
+  /** e.g. <>Already have an account? <Link to="/login">Sign in</Link></> */
+  signInPrompt?: ReactNode;
+  /**
+   * Start directly on the confirm step for this email (used when sign-in
+   * discovers an unconfirmed account — a fresh code is already sent).
+   */
+  initialConfirmEmail?: string;
+}
+
+type Step = 'details' | 'confirm';
+
+export function SignUpForm({ onSuccess, logo, signInPrompt, initialConfirmEmail }: SignUpFormProps) {
+  const [step, setStep] = useState<Step>(initialConfirmEmail ? 'confirm' : 'details');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState(initialConfirmEmail ?? '');
+  const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    password?: string;
+    code?: string;
+  }>({});
+  const [busy, setBusy] = useState(false);
+
+  const submitDetails = async (e: FormEvent) => {
+    e.preventDefault();
+    const errors = {
+      firstName: validateName(firstName, 'first name'),
+      lastName: validateName(lastName, 'last name'),
+      email: validateEmail(email),
+      password: validatePassword(password)
+    };
+    setFieldErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
+
+    setBusy(true);
+    setError('');
+    try {
+      await signUp(firstName, lastName, email.trim(), password);
+      setStep('confirm');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitCode = async (e: FormEvent) => {
+    e.preventDefault();
+    const codeError = validateCode(code);
+    setFieldErrors({ code: codeError });
+    if (codeError) return;
+
+    setBusy(true);
+    setError('');
+    try {
+      await confirmSignUp(email.trim(), code.trim());
+      // Sign in immediately when we still hold the password; when arriving
+      // from the "unconfirmed account" path we don't, so the app routes to
+      // sign-in from onSuccess.
+      if (password) await signIn(email.trim(), password).catch(() => {});
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (step === 'confirm') {
+    return (
+      <AuthCard
+        title="Check your email"
+        subtitle={`We sent a 6-digit code to ${email.trim()}.`}
+        logo={logo}
+      >
+        <form onSubmit={submitCode} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {error && <Alert variant="error">{error}</Alert>}
+          <CodeInput
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            error={fieldErrors.code}
+            autoFocus
+          />
+          <Button type="submit" block loading={busy} loadingLabel="Verifying…">
+            Verify email
+          </Button>
+          <div style={{ textAlign: 'center' }}>
+            <ResendCodeButton email={email.trim()} onError={setError} />
+          </div>
+        </form>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title="Create your account"
+      subtitle="One account across every Ready, Set, Cloud app."
+      logo={logo}
+      footer={signInPrompt}
+    >
+      <form onSubmit={submitDetails} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {error && <Alert variant="error">{error}</Alert>}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+          <Input
+            label="First name"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            error={fieldErrors.firstName}
+            autoComplete="given-name"
+            autoFocus
+          />
+          <Input
+            label="Last name"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            error={fieldErrors.lastName}
+            autoComplete="family-name"
+          />
+        </div>
+        <Input
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={fieldErrors.email}
+          autoComplete="email"
+        />
+        <PasswordInput
+          label="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={fieldErrors.password}
+          autoComplete="new-password"
+        />
+        <PasswordRequirements />
+        <Button type="submit" block loading={busy} loadingLabel="Creating account…">
+          Create account
+        </Button>
+      </form>
+    </AuthCard>
+  );
+}

--- a/ui/src/auth/config.ts
+++ b/ui/src/auth/config.ts
@@ -1,0 +1,46 @@
+/*
+ * Auth configuration — injected by the consuming app.
+ *
+ * Apps share ONE Cognito user pool (rsc-core exposes the pool id/client id
+ * via SSM: /readysetcloud/auth/*) but each supplies its own app client.
+ *
+ * Accepts either a static config or an async loader (e.g. concurrency
+ * bootcamp fetches /auth-config.json at runtime):
+ *
+ *   configureAuth({ region: 'us-east-1', clientId: '...' });
+ *   configureAuth(async () => (await fetch('/auth-config.json')).json());
+ */
+
+export interface AuthConfig {
+  region: string;
+  clientId: string;
+}
+
+type ConfigSource = AuthConfig | (() => Promise<AuthConfig | null>) | null;
+
+let source: ConfigSource = null;
+let cached: AuthConfig | null = null;
+let pending: Promise<AuthConfig | null> | null = null;
+
+export function configureAuth(config: ConfigSource): void {
+  source = config;
+  cached = null;
+  pending = null;
+}
+
+export async function getConfig(): Promise<AuthConfig | null> {
+  if (cached) return cached;
+  if (!source) return null;
+  if (typeof source !== 'function') {
+    cached = source;
+    return cached;
+  }
+  // dedupe concurrent loads
+  pending ??= source().catch(() => null);
+  const loaded = await pending;
+  pending = null;
+  if (loaded && typeof loaded.region === 'string' && typeof loaded.clientId === 'string') {
+    cached = loaded;
+  }
+  return cached;
+}

--- a/ui/src/auth/core.test.ts
+++ b/ui/src/auth/core.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configureAuth } from './config';
+import {
+  AUTH_KEY,
+  claims,
+  errorMessage,
+  getFreshIdToken,
+  isSignedIn,
+  readSession,
+  signIn,
+  signOut
+} from './core';
+
+const CONFIG = { region: 'us-east-1', clientId: 'test-client' };
+
+/** Base64url-encode a JWT payload the way Cognito does. */
+const fakeJwt = (payload: object): string =>
+  `header.${btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')}.sig`;
+
+const seedSession = (overrides: Partial<{ idToken: string; refreshToken: string; expiresAt: number }> = {}) => {
+  localStorage.setItem(
+    AUTH_KEY,
+    JSON.stringify({
+      idToken: fakeJwt({ email: 'allen@readysetcloud.io', given_name: 'Allen' }),
+      refreshToken: 'refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      ...overrides
+    })
+  );
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  configureAuth(CONFIG);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('errorMessage', () => {
+  it('maps known Cognito error types to friendly copy', () => {
+    expect(errorMessage({ __type: 'NotAuthorizedException' })).toBe('Incorrect email or password.');
+    expect(
+      errorMessage({ __type: 'com.amazon#CodeMismatchException' })
+    ).toBe("That code isn't right — check it and try again.");
+  });
+
+  it('falls back to the raw message, then generic copy', () => {
+    expect(errorMessage({ __type: 'SomethingNew', message: 'Custom detail' })).toBe('Custom detail');
+    expect(errorMessage({})).toBe('Something went wrong — please try again.');
+  });
+});
+
+describe('session document', () => {
+  it('reads a valid rsc:auth document', () => {
+    seedSession();
+    expect(isSignedIn()).toBe(true);
+    expect(readSession()?.refreshToken).toBe('refresh-token');
+  });
+
+  it('rejects malformed documents', () => {
+    localStorage.setItem(AUTH_KEY, 'not json');
+    expect(readSession()).toBeNull();
+    localStorage.setItem(AUTH_KEY, JSON.stringify({ idToken: 42 }));
+    expect(readSession()).toBeNull();
+  });
+
+  it('parses id token claims defensively', () => {
+    seedSession();
+    expect(claims().email).toBe('allen@readysetcloud.io');
+    localStorage.setItem(
+      AUTH_KEY,
+      JSON.stringify({ idToken: 'garbage', expiresAt: Math.floor(Date.now() / 1000) + 3600 })
+    );
+    expect(claims()).toEqual({});
+  });
+});
+
+describe('signIn', () => {
+  it('saves the session on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          AuthenticationResult: { IdToken: fakeJwt({ email: 'a@b.co' }), RefreshToken: 'rt', ExpiresIn: 3600 }
+        })
+      })
+    );
+    const result = await signIn('a@b.co', 'Password1');
+    expect(result.kind).toBe('success');
+    expect(isSignedIn()).toBe(true);
+  });
+
+  it('surfaces the new-password challenge without saving a session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ChallengeName: 'NEW_PASSWORD_REQUIRED', Session: 'challenge-session' })
+      })
+    );
+    const result = await signIn('a@b.co', 'Password1');
+    expect(result).toEqual({ kind: 'newPasswordRequired', session: 'challenge-session' });
+    expect(isSignedIn()).toBe(false);
+  });
+
+  it('throws friendly errors from Cognito error bodies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ __type: 'NotAuthorizedException' })
+      })
+    );
+    await expect(signIn('a@b.co', 'wrong')).rejects.toThrow('Incorrect email or password.');
+  });
+});
+
+describe('getFreshIdToken', () => {
+  it('returns the current token when not near expiry', async () => {
+    seedSession();
+    const fetchSpy = vi.stubGlobal('fetch', vi.fn());
+    const token = await getFreshIdToken();
+    expect(token).toBe(readSession()?.idToken);
+    expect(fetchSpy).toBeDefined();
+  });
+
+  it('refreshes an expired token', async () => {
+    seedSession({ expiresAt: Math.floor(Date.now() / 1000) - 10 });
+    const newToken = fakeJwt({ email: 'a@b.co', fresh: true });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ AuthenticationResult: { IdToken: newToken, ExpiresIn: 3600 } })
+      })
+    );
+    expect(await getFreshIdToken()).toBe(newToken);
+    // refresh token carried over from the previous session document
+    expect(readSession()?.refreshToken).toBe('refresh-token');
+  });
+
+  it('clears the session on a definite auth failure', async () => {
+    seedSession({ expiresAt: Math.floor(Date.now() / 1000) - 10 });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ __type: 'NotAuthorizedException' })
+      })
+    );
+    expect(await getFreshIdToken()).toBeNull();
+    expect(isSignedIn()).toBe(false);
+  });
+
+  it('keeps tokens on network failure (offline must not sign out)', async () => {
+    seedSession({ expiresAt: Math.floor(Date.now() / 1000) - 10 });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network down')));
+    expect(await getFreshIdToken()).toBeNull();
+    expect(isSignedIn()).toBe(true);
+  });
+});
+
+describe('signOut', () => {
+  it('clears the session and revokes the refresh token', async () => {
+    seedSession();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+    await signOut();
+    expect(isSignedIn()).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cognito-idp.us-east-1.amazonaws.com/',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-amz-target': 'AWSCognitoIdentityProviderService.RevokeToken'
+        })
+      })
+    );
+  });
+});
+
+describe('unconfigured auth', () => {
+  it('fails with a clear message when configureAuth was never called', async () => {
+    configureAuth(null);
+    await expect(signIn('a@b.co', 'pw')).rejects.toThrow(/configureAuth/);
+  });
+});

--- a/ui/src/auth/core.ts
+++ b/ui/src/auth/core.ts
@@ -1,0 +1,340 @@
+/*
+ * The shared RSC auth core — promoted from concurrency-bootcamp's
+ * platform/src/lib/auth.ts, which itself is the TypeScript port of the
+ * original js/account.js implementation.
+ *
+ * The session contract every RSC surface shares is the `rsc:auth`
+ * localStorage document ({idToken, refreshToken, expiresAt}) plus plain
+ * Cognito user pool API calls. No SDK, no Hosted UI — cognito-idp over TLS.
+ *
+ * NOTE: localStorage is per-origin, so this contract shares a session
+ * between surfaces on the SAME subdomain (e.g. a platform SPA and its
+ * course pages). True SSO across *.readysetcloud.io subdomains needs a
+ * parent-domain cookie and is a deliberate future change to this file.
+ */
+
+import { getConfig, type AuthConfig } from './config';
+
+export const AUTH_KEY = 'rsc:auth';
+
+export interface Session {
+  idToken: string;
+  refreshToken?: string;
+  expiresAt: number; // epoch seconds
+}
+
+export interface IdClaims {
+  email?: string;
+  given_name?: string;
+  family_name?: string;
+  sub?: string;
+  [claim: string]: unknown;
+}
+
+export type SignInResult =
+  | { kind: 'success' }
+  | { kind: 'newPasswordRequired'; session: string };
+
+/* ---------- friendly error translation ---------- */
+
+const ERROR_COPY: Record<string, string> = {
+  NotAuthorizedException: 'Incorrect email or password.',
+  UserNotFoundException: 'Incorrect email or password.',
+  UsernameExistsException: 'An account with this email already exists.',
+  InvalidPasswordException: "That password doesn't meet the requirements below.",
+  CodeMismatchException: "That code isn't right — check it and try again.",
+  ExpiredCodeException: 'That code has expired — request a new one.',
+  LimitExceededException: 'Too many attempts — wait a few minutes and try again.',
+  TooManyRequestsException: 'Too many attempts — wait a moment and try again.',
+  UserNotConfirmedException: "This account hasn't verified its email yet."
+};
+
+const errorCode = (body: { __type?: unknown }): string =>
+  (String(body.__type ?? '').split('#').pop() ?? '').replace(/:.*$/, '');
+
+/** Exported for tests: raw Cognito error body -> copy a human should read. */
+export function errorMessage(body: { __type?: unknown; message?: unknown }): string {
+  return (
+    ERROR_COPY[errorCode(body)] ||
+    (typeof body.message === 'string' ? body.message : '') ||
+    'Something went wrong — please try again.'
+  );
+}
+
+export class AuthError extends Error {
+  readonly code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'AuthError';
+    this.code = code;
+  }
+}
+
+export const isAuthError = (e: unknown): e is AuthError => e instanceof AuthError;
+
+/* ---------- the session document ---------- */
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+export function readSession(): Session | null {
+  try {
+    const raw = localStorage.getItem(AUTH_KEY);
+    if (!raw) return null;
+    const doc = JSON.parse(raw) as Partial<Session> | null;
+    if (!doc || typeof doc.idToken !== 'string' || typeof doc.expiresAt !== 'number') return null;
+    return doc as Session;
+  } catch {
+    return null;
+  }
+}
+
+export const isSignedIn = (): boolean => !!readSession();
+
+/** Parse the id token payload (base64url JWT) — defensive read. */
+export function claims(): IdClaims {
+  const session = readSession();
+  if (!session) return {};
+  try {
+    const payload = session.idToken.split('.')[1]!.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(payload)) as IdClaims;
+  } catch {
+    return {};
+  }
+}
+
+/* ---------- change notification (React re-renders + cross-tab) ---------- */
+
+const listeners = new Set<() => void>();
+
+export function onAuthChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function notify(): void {
+  for (const listener of [...listeners]) {
+    try {
+      listener();
+    } catch {
+      /* one bad listener never blocks the rest */
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // a sign-in/out in another tab updates this one
+  window.addEventListener('storage', (e) => {
+    if (e.key === AUTH_KEY || e.key === null) notify();
+  });
+}
+
+interface CognitoAuthResult {
+  IdToken?: string;
+  RefreshToken?: string;
+  ExpiresIn?: number;
+}
+
+function saveAuthResult(result: CognitoAuthResult | undefined): void {
+  if (!result?.IdToken) return;
+  const prev = readSession();
+  const session: Session = {
+    idToken: result.IdToken,
+    refreshToken: result.RefreshToken || prev?.refreshToken,
+    expiresAt: nowSec() + (result.ExpiresIn || 3600)
+  };
+  try {
+    localStorage.setItem(AUTH_KEY, JSON.stringify(session));
+  } catch {
+    /* storage unavailable — stay signed out rather than crash */
+  }
+  notify();
+}
+
+function clearSession(): void {
+  try {
+    localStorage.removeItem(AUTH_KEY);
+  } catch {
+    /* ignore */
+  }
+  notify();
+}
+
+/* ---------- Cognito user pool API ---------- */
+
+interface InitiateAuthResponse {
+  AuthenticationResult?: CognitoAuthResult;
+  ChallengeName?: string;
+  Session?: string;
+}
+
+async function requireConfig(): Promise<AuthConfig> {
+  const config = await getConfig();
+  if (!config) {
+    throw new AuthError(
+      'Auth is not configured — call configureAuth() before using auth functions.',
+      'ConfigMissing'
+    );
+  }
+  return config;
+}
+
+async function idp<T>(region: string, action: string, payload: unknown): Promise<T> {
+  const res = await fetch(`https://cognito-idp.${region}.amazonaws.com/`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-amz-json-1.1',
+      'x-amz-target': `AWSCognitoIdentityProviderService.${action}`
+    },
+    body: JSON.stringify(payload)
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new AuthError(errorMessage(body), errorCode(body));
+  return body as T;
+}
+
+/* ---------- operations ---------- */
+
+export async function signIn(email: string, password: string): Promise<SignInResult> {
+  const config = await requireConfig();
+  try {
+    const out = await idp<InitiateAuthResponse>(config.region, 'InitiateAuth', {
+      AuthFlow: 'USER_PASSWORD_AUTH',
+      ClientId: config.clientId,
+      AuthParameters: { USERNAME: email, PASSWORD: password }
+    });
+    if (out.ChallengeName === 'NEW_PASSWORD_REQUIRED') {
+      return { kind: 'newPasswordRequired', session: out.Session ?? '' };
+    }
+    saveAuthResult(out.AuthenticationResult);
+    return { kind: 'success' };
+  } catch (e) {
+    if (isAuthError(e) && e.code === 'UserNotConfirmedException') {
+      // best-effort: a fresh code is already on its way when the UI lands
+      // on the confirm screen
+      await resendConfirmationCode(email).catch(() => {});
+    }
+    throw e;
+  }
+}
+
+export async function signUp(
+  firstName: string,
+  lastName: string,
+  email: string,
+  password: string
+): Promise<void> {
+  const config = await requireConfig();
+  await idp(config.region, 'SignUp', {
+    ClientId: config.clientId,
+    Username: email,
+    Password: password,
+    UserAttributes: [
+      // the shared pool REQUIRES given_name/family_name
+      { Name: 'email', Value: email },
+      { Name: 'given_name', Value: firstName.trim() },
+      { Name: 'family_name', Value: lastName.trim() }
+    ]
+  });
+}
+
+export async function confirmSignUp(email: string, code: string): Promise<void> {
+  const config = await requireConfig();
+  await idp(config.region, 'ConfirmSignUp', {
+    ClientId: config.clientId,
+    Username: email,
+    ConfirmationCode: code
+  });
+}
+
+export async function resendConfirmationCode(email: string): Promise<void> {
+  const config = await requireConfig();
+  await idp(config.region, 'ResendConfirmationCode', {
+    ClientId: config.clientId,
+    Username: email
+  });
+}
+
+export async function forgotPassword(email: string): Promise<void> {
+  const config = await requireConfig();
+  await idp(config.region, 'ForgotPassword', {
+    ClientId: config.clientId,
+    Username: email
+  });
+}
+
+export async function confirmForgotPassword(
+  email: string,
+  code: string,
+  newPassword: string
+): Promise<void> {
+  const config = await requireConfig();
+  await idp(config.region, 'ConfirmForgotPassword', {
+    ClientId: config.clientId,
+    Username: email,
+    ConfirmationCode: code,
+    Password: newPassword
+  });
+}
+
+export async function respondNewPassword(
+  email: string,
+  newPassword: string,
+  session: string
+): Promise<void> {
+  const config = await requireConfig();
+  const out = await idp<InitiateAuthResponse>(config.region, 'RespondToAuthChallenge', {
+    ClientId: config.clientId,
+    ChallengeName: 'NEW_PASSWORD_REQUIRED',
+    Session: session,
+    ChallengeResponses: { USERNAME: email, NEW_PASSWORD: newPassword }
+  });
+  saveAuthResult(out.AuthenticationResult);
+}
+
+/** Valid id token, refreshing behind the scenes when it's near expiry.
+    Definite auth failures clear the session; network errors keep the tokens
+    (offline shouldn't sign anyone out) and return null. */
+export async function getFreshIdToken(): Promise<string | null> {
+  const session = readSession();
+  if (!session) return null;
+  if (session.expiresAt - 60 > nowSec()) return session.idToken;
+  if (!session.refreshToken) {
+    clearSession();
+    return null;
+  }
+  const config = await getConfig();
+  if (!config) return null;
+  try {
+    const out = await idp<InitiateAuthResponse>(config.region, 'InitiateAuth', {
+      AuthFlow: 'REFRESH_TOKEN_AUTH',
+      ClientId: config.clientId,
+      AuthParameters: { REFRESH_TOKEN: session.refreshToken }
+    });
+    saveAuthResult(out.AuthenticationResult);
+    return readSession()?.idToken ?? null;
+  } catch (e) {
+    // a Cognito error body means the session is revoked/expired for real;
+    // anything else (offline, 5xx without a body) keeps the tokens
+    if (isAuthError(e) && e.code) clearSession();
+    return null;
+  }
+}
+
+/** Drop rsc:auth (and nothing else), then best-effort revoke the refresh token. */
+export async function signOut(): Promise<void> {
+  const session = readSession();
+  clearSession();
+  if (!session?.refreshToken) return;
+  try {
+    const config = await getConfig();
+    if (!config) return;
+    await idp(config.region, 'RevokeToken', {
+      ClientId: config.clientId,
+      Token: session.refreshToken
+    });
+  } catch {
+    /* best effort */
+  }
+}

--- a/ui/src/auth/index.ts
+++ b/ui/src/auth/index.ts
@@ -1,0 +1,50 @@
+// @readysetcloud/ui/auth — shared Cognito auth (core + React)
+
+// configuration
+export { configureAuth, getConfig, type AuthConfig } from './config';
+
+// framework-agnostic core
+export {
+  AUTH_KEY,
+  AuthError,
+  isAuthError,
+  errorMessage,
+  readSession,
+  isSignedIn,
+  claims,
+  onAuthChange,
+  signIn,
+  signUp,
+  confirmSignUp,
+  resendConfirmationCode,
+  forgotPassword,
+  confirmForgotPassword,
+  respondNewPassword,
+  getFreshIdToken,
+  signOut,
+  type Session,
+  type IdClaims,
+  type SignInResult
+} from './core';
+
+// validation (matches the pool policy in rsc-core template.yaml)
+export {
+  isValidEmail,
+  isValidPassword,
+  validateEmail,
+  validatePassword,
+  validateName,
+  validateCode,
+  PASSWORD_REQUIREMENTS
+} from './validate';
+
+// React bindings
+export { AuthProvider, useAuth, RequireAuth, type AuthState, type RequireAuthProps } from './react';
+
+// flow components
+export { AuthCard, type AuthCardProps } from './components/AuthCard';
+export { LoginForm, type LoginFormProps } from './components/LoginForm';
+export { SignUpForm, type SignUpFormProps } from './components/SignUpForm';
+export { ForgotPasswordForm, type ForgotPasswordFormProps } from './components/ForgotPasswordForm';
+export { PasswordRequirements } from './components/PasswordRequirements';
+export { ResendCodeButton, type ResendCodeButtonProps } from './components/ResendCodeButton';

--- a/ui/src/auth/react.tsx
+++ b/ui/src/auth/react.tsx
@@ -1,0 +1,77 @@
+/*
+ * React bindings for the shared auth core.
+ *
+ * Router-agnostic on purpose: RequireAuth renders a `fallback` node when
+ * signed out — pass your router's redirect (e.g. <Navigate to="/login" />).
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react';
+import {
+  claims,
+  getFreshIdToken,
+  isSignedIn,
+  onAuthChange,
+  signOut as coreSignOut,
+  type IdClaims
+} from './core';
+
+export interface AuthState {
+  /** True when an rsc:auth session document exists. */
+  signedIn: boolean;
+  /** Decoded id-token claims ({} when signed out). */
+  user: IdClaims;
+  /** Valid id token for API calls, auto-refreshing near expiry. */
+  getToken: () => Promise<string | null>;
+  /** Clear the session and best-effort revoke the refresh token. */
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [signedIn, setSignedIn] = useState<boolean>(() => isSignedIn());
+  const [user, setUser] = useState<IdClaims>(() => claims());
+
+  useEffect(() => {
+    // core notifies on sign-in/out in this tab and (via storage events) others
+    return onAuthChange(() => {
+      setSignedIn(isSignedIn());
+      setUser(claims());
+    });
+  }, []);
+
+  const getToken = useCallback(() => getFreshIdToken(), []);
+  const signOut = useCallback(() => coreSignOut(), []);
+
+  const value = useMemo<AuthState>(
+    () => ({ signedIn, user, getToken, signOut }),
+    [signedIn, user, getToken, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}
+
+export interface RequireAuthProps {
+  children: ReactNode;
+  /** Rendered when signed out — typically your router's redirect. */
+  fallback: ReactNode;
+}
+
+export function RequireAuth({ children, fallback }: RequireAuthProps) {
+  const { signedIn } = useAuth();
+  return <>{signedIn ? children : fallback}</>;
+}

--- a/ui/src/auth/validate.test.ts
+++ b/ui/src/auth/validate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isValidEmail, isValidPassword, validateCode } from './validate';
+
+describe('password policy (mirrors pool: 8+, upper, lower, number, NO symbol requirement)', () => {
+  it('accepts the minimum compliant password', () => {
+    expect(isValidPassword('Abcdefg1')).toBe(true);
+  });
+
+  it('accepts symbols without requiring them', () => {
+    expect(isValidPassword('Abcdefg1!')).toBe(true);
+  });
+
+  it('rejects missing classes and short passwords', () => {
+    expect(isValidPassword('abcdefg1')).toBe(false); // no uppercase
+    expect(isValidPassword('ABCDEFG1')).toBe(false); // no lowercase
+    expect(isValidPassword('Abcdefgh')).toBe(false); // no number
+    expect(isValidPassword('Abcdef1')).toBe(false); // 7 chars
+  });
+});
+
+describe('email', () => {
+  it('accepts normal addresses and trims whitespace', () => {
+    expect(isValidEmail(' allen@readysetcloud.io ')).toBe(true);
+  });
+
+  it('rejects partial addresses', () => {
+    expect(isValidEmail('allen@')).toBe(false);
+    expect(isValidEmail('allen@readysetcloud')).toBe(false);
+  });
+});
+
+describe('code', () => {
+  it('requires exactly six digits', () => {
+    expect(validateCode('123456')).toBeUndefined();
+    expect(validateCode(' 123456 ')).toBeUndefined();
+    expect(validateCode('12345')).toBeTruthy();
+    expect(validateCode('12345a')).toBeTruthy();
+  });
+});

--- a/ui/src/auth/validate.ts
+++ b/ui/src/auth/validate.ts
@@ -1,0 +1,40 @@
+/*
+ * Form validation matching the ACTUAL pool policy (rsc-core template.yaml):
+ * MinimumLength 8, RequireUppercase, RequireLowercase, RequireNumbers,
+ * RequireSymbols: false.
+ */
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PASSWORD_RE = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+export const isValidEmail = (email: string): boolean => EMAIL_RE.test(email.trim());
+
+export const isValidPassword = (password: string): boolean => PASSWORD_RE.test(password);
+
+export const PASSWORD_REQUIREMENTS = [
+  'At least 8 characters',
+  'One uppercase and one lowercase letter',
+  'At least one number'
+] as const;
+
+export function validateEmail(email: string): string | undefined {
+  if (!email.trim()) return 'Enter your email address.';
+  if (!isValidEmail(email)) return 'Enter a full email address, e.g. you@example.com';
+  return undefined;
+}
+
+export function validatePassword(password: string): string | undefined {
+  if (!password) return 'Enter a password.';
+  if (!isValidPassword(password)) return "That password doesn't meet the requirements below.";
+  return undefined;
+}
+
+export function validateName(value: string, label: string): string | undefined {
+  if (!value.trim()) return `Enter your ${label}.`;
+  return undefined;
+}
+
+export function validateCode(code: string): string | undefined {
+  if (!/^\d{6}$/.test(code.trim())) return 'Enter the 6-digit code from your email.';
+  return undefined;
+}

--- a/ui/src/components/Alert.tsx
+++ b/ui/src/components/Alert.tsx
@@ -1,0 +1,18 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export type AlertVariant = 'error' | 'success' | 'info';
+
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: AlertVariant;
+}
+
+export function Alert({ variant = 'info', className, ...rest }: AlertProps) {
+  return (
+    <div
+      role={variant === 'error' ? 'alert' : 'status'}
+      className={cx('alert', `alert-${variant}`, className)}
+      {...rest}
+    />
+  );
+}

--- a/ui/src/components/Badge.tsx
+++ b/ui/src/components/Badge.tsx
@@ -1,0 +1,12 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export type BadgeVariant = 'primary' | 'success' | 'warning' | 'error' | 'neutral';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+export function Badge({ variant = 'neutral', className, ...rest }: BadgeProps) {
+  return <span className={cx('badge', `badge-${variant}`, className)} {...rest} />;
+}

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -1,0 +1,58 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { cx } from './cx';
+import { Spinner } from './Spinner';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'ghost';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: 'sm' | 'md' | 'lg';
+  /** Full-width button. */
+  block?: boolean;
+  /** Shows a spinner, disables the button, and (if set) swaps the label. */
+  loading?: boolean;
+  loadingLabel?: string;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    block = false,
+    loading = false,
+    loadingLabel,
+    className,
+    children,
+    disabled,
+    type = 'button',
+    ...rest
+  },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={cx(
+        'btn',
+        `btn-${variant}`,
+        size === 'sm' && 'btn-sm',
+        size === 'lg' && 'btn-lg',
+        block && 'btn-block',
+        className
+      )}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...rest}
+    >
+      {loading && <Spinner />}
+      {loading && loadingLabel ? loadingLabel : children}
+    </button>
+  );
+});

--- a/ui/src/components/Card.tsx
+++ b/ui/src/components/Card.tsx
@@ -1,0 +1,26 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export function Card({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('card', className)} {...rest} />;
+}
+
+export function CardHeader({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('card-header', className)} {...rest} />;
+}
+
+export function CardTitle({ className, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cx('card-title', className)} {...rest} />;
+}
+
+export function CardDescription({ className, ...rest }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cx('card-description', className)} {...rest} />;
+}
+
+export function CardBody({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('card-body', className)} {...rest} />;
+}
+
+export function CardFooter({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('card-footer', className)} {...rest} />;
+}

--- a/ui/src/components/Container.tsx
+++ b/ui/src/components/Container.tsx
@@ -1,0 +1,7 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+/** Responsive page container: max 72rem, fluid inline padding. */
+export function Container({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('container-rsc', className)} {...rest} />;
+}

--- a/ui/src/components/EmptyState.tsx
+++ b/ui/src/components/EmptyState.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+export interface EmptyStateProps {
+  title: ReactNode;
+  description?: ReactNode;
+  /** Icon or illustration shown above the title. */
+  icon?: ReactNode;
+  /** Call-to-action, e.g. a <Button>. */
+  action?: ReactNode;
+}
+
+export function EmptyState({ title, description, icon, action }: EmptyStateProps) {
+  return (
+    <div className="empty-state">
+      {icon}
+      <div className="empty-state-title">{title}</div>
+      {description && <p style={{ margin: 0, fontSize: '0.875rem' }}>{description}</p>}
+      {action && <div style={{ marginTop: '0.5rem' }}>{action}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/Field.tsx
+++ b/ui/src/components/Field.tsx
@@ -1,0 +1,45 @@
+import { useId, type ReactNode } from 'react';
+
+export interface FieldRenderProps {
+  id: string;
+  'aria-invalid': true | undefined;
+  'aria-describedby': string | undefined;
+}
+
+export interface FieldProps {
+  label: ReactNode;
+  error?: string;
+  hint?: string;
+  /** Renders the control, wired with id/aria attributes. */
+  children: (props: FieldRenderProps) => ReactNode;
+}
+
+/**
+ * Label + control + hint/error wrapper. Render-prop so any control
+ * (input, textarea, select, custom) gets correct label/aria wiring.
+ */
+export function Field({ label, error, hint, children }: FieldProps) {
+  const id = useId();
+  const describedBy = error ? `${id}-error` : hint ? `${id}-hint` : undefined;
+  return (
+    <div className="field">
+      <label className="field-label" htmlFor={id}>
+        {label}
+      </label>
+      {children({
+        id,
+        'aria-invalid': error ? true : undefined,
+        'aria-describedby': describedBy
+      })}
+      {error ? (
+        <span id={`${id}-error`} className="field-error" role="alert">
+          {error}
+        </span>
+      ) : hint ? (
+        <span id={`${id}-hint`} className="field-hint">
+          {hint}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/Input.tsx
+++ b/ui/src/components/Input.tsx
@@ -1,0 +1,103 @@
+import { forwardRef, useState, type InputHTMLAttributes } from 'react';
+import { cx } from './cx';
+import { Field } from './Field';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, error, hint, className, ...rest },
+  ref
+) {
+  return (
+    <Field label={label} error={error} hint={hint}>
+      {(field) => (
+        <input
+          ref={ref}
+          className={cx('input', error && 'input-error', className)}
+          {...field}
+          {...rest}
+        />
+      )}
+    </Field>
+  );
+});
+
+export interface PasswordInputProps extends Omit<InputProps, 'type'> {}
+
+/** Password input with a show/hide toggle. */
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  function PasswordInput({ label, error, hint, className, ...rest }, ref) {
+    const [visible, setVisible] = useState(false);
+    return (
+      <Field label={label} error={error} hint={hint}>
+        {(field) => (
+          <div style={{ position: 'relative' }}>
+            <input
+              ref={ref}
+              type={visible ? 'text' : 'password'}
+              className={cx('input', error && 'input-error', className)}
+              style={{ paddingRight: '3.25rem' }}
+              {...field}
+              {...rest}
+            />
+            <button
+              type="button"
+              onClick={() => setVisible((v) => !v)}
+              aria-label={visible ? 'Hide password' : 'Show password'}
+              className="auth-link"
+              style={{
+                position: 'absolute',
+                right: '0.5rem',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+                minHeight: 'auto'
+              }}
+            >
+              {visible ? 'Hide' : 'Show'}
+            </button>
+          </div>
+        )}
+      </Field>
+    );
+  }
+);
+
+export interface CodeInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'inputMode' | 'maxLength'> {
+  label?: string;
+  error?: string;
+  /** Number of digits (default 6 — Cognito confirmation codes). */
+  length?: number;
+}
+
+/** Numeric verification-code input (email confirmation, password reset). */
+export const CodeInput = forwardRef<HTMLInputElement, CodeInputProps>(function CodeInput(
+  { label = 'Verification code', error, length = 6, className, ...rest },
+  ref
+) {
+  return (
+    <Field label={label} error={error}>
+      {(field) => (
+        <input
+          ref={ref}
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          pattern="[0-9]*"
+          maxLength={length}
+          className={cx('input', 'input-code', error && 'input-error', className)}
+          {...field}
+          {...rest}
+        />
+      )}
+    </Field>
+  );
+});

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { cx } from './cx';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+  /** Accessible label for the dialog. */
+  'aria-label'?: string;
+}
+
+/**
+ * Native <dialog>-based modal: focus trapping, Esc-to-close, and ::backdrop
+ * come from the platform. Renders as a bottom sheet on small screens
+ * (see .modal in components.css).
+ */
+export function Modal({ open, onClose, children, className, ...rest }: ModalProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      className={cx('modal', className)}
+      onClose={onClose}
+      onClick={(e) => {
+        // click on the backdrop (the dialog element itself) closes
+        if (e.target === ref.current) onClose();
+      }}
+      {...rest}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/ui/src/components/Select.tsx
+++ b/ui/src/components/Select.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, type SelectHTMLAttributes } from 'react';
+import { cx } from './cx';
+import { Field } from './Field';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { label, error, hint, className, children, ...rest },
+  ref
+) {
+  return (
+    <Field label={label} error={error} hint={hint}>
+      {(field) => (
+        <select
+          ref={ref}
+          className={cx('input', error && 'input-error', className)}
+          {...field}
+          {...rest}
+        >
+          {children}
+        </select>
+      )}
+    </Field>
+  );
+});

--- a/ui/src/components/Skeleton.tsx
+++ b/ui/src/components/Skeleton.tsx
@@ -1,0 +1,18 @@
+import type { CSSProperties, HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+}
+
+export function Skeleton({ width = '100%', height = '1rem', className, style, ...rest }: SkeletonProps) {
+  return (
+    <div
+      className={cx('skeleton', className)}
+      style={{ width, height, ...style }}
+      aria-hidden="true"
+      {...rest}
+    />
+  );
+}

--- a/ui/src/components/Spinner.tsx
+++ b/ui/src/components/Spinner.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export function Spinner({ className, ...rest }: HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cx('spinner', className)} aria-hidden="true" {...rest} />;
+}

--- a/ui/src/components/TextArea.tsx
+++ b/ui/src/components/TextArea.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+import { cx } from './cx';
+import { Field } from './Field';
+
+export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label: string;
+  error?: string;
+  hint?: string;
+}
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function TextArea(
+  { label, error, hint, className, rows = 4, ...rest },
+  ref
+) {
+  return (
+    <Field label={label} error={error} hint={hint}>
+      {(field) => (
+        <textarea
+          ref={ref}
+          rows={rows}
+          className={cx('input', error && 'input-error', className)}
+          {...field}
+          {...rest}
+        />
+      )}
+    </Field>
+  );
+});

--- a/ui/src/components/Toast.tsx
+++ b/ui/src/components/Toast.tsx
@@ -1,0 +1,98 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react';
+import { createPortal } from 'react-dom';
+import { cx } from './cx';
+
+export type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+export interface ToastOptions {
+  variant?: ToastVariant;
+  /** Auto-dismiss delay in ms (default 5000; errors default to 8000). */
+  duration?: number;
+}
+
+interface ToastItem {
+  id: number;
+  message: ReactNode;
+  variant: ToastVariant;
+}
+
+interface ToastApi {
+  toast: (message: ReactNode, options?: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastApi | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+  const nextId = useRef(0);
+
+  const dismiss = useCallback((id: number) => {
+    setItems((current) => current.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (message: ReactNode, options?: ToastOptions) => {
+      const id = nextId.current++;
+      const variant = options?.variant ?? 'info';
+      const duration = options?.duration ?? (variant === 'error' ? 8000 : 5000);
+      setItems((current) => [...current, { id, message, variant }]);
+      window.setTimeout(() => dismiss(id), duration);
+    },
+    [dismiss]
+  );
+
+  const api = useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <div className="toast-viewport" role="region" aria-label="Notifications">
+            {items.map((t) => (
+              <div
+                key={t.id}
+                className={cx('toast', `toast-${t.variant}`)}
+                role={t.variant === 'error' ? 'alert' : 'status'}
+              >
+                <span style={{ flex: 1 }}>{t.message}</span>
+                <button
+                  type="button"
+                  onClick={() => dismiss(t.id)}
+                  aria-label="Dismiss notification"
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: 'inherit',
+                    opacity: 0.6,
+                    minHeight: 'auto',
+                    padding: 0,
+                    fontSize: '1rem',
+                    lineHeight: 1
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used inside <ToastProvider>');
+  return ctx;
+}

--- a/ui/src/components/cx.ts
+++ b/ui/src/components/cx.ts
@@ -1,0 +1,3 @@
+/** Tiny classnames join — avoids a clsx dependency. */
+export const cx = (...parts: Array<string | false | null | undefined>): string =>
+  parts.filter(Boolean).join(' ');

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,0 +1,30 @@
+// @readysetcloud/ui — shared components
+export { cx } from './components/cx';
+export { Button, type ButtonProps, type ButtonVariant } from './components/Button';
+export { Spinner } from './components/Spinner';
+export { Field, type FieldProps, type FieldRenderProps } from './components/Field';
+export {
+  Input,
+  PasswordInput,
+  CodeInput,
+  type InputProps,
+  type PasswordInputProps,
+  type CodeInputProps
+} from './components/Input';
+export { TextArea, type TextAreaProps } from './components/TextArea';
+export { Select, type SelectProps } from './components/Select';
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardBody,
+  CardFooter
+} from './components/Card';
+export { Badge, type BadgeProps, type BadgeVariant } from './components/Badge';
+export { Alert, type AlertProps, type AlertVariant } from './components/Alert';
+export { Modal, type ModalProps } from './components/Modal';
+export { ToastProvider, useToast, type ToastOptions, type ToastVariant } from './components/Toast';
+export { Skeleton, type SkeletonProps } from './components/Skeleton';
+export { EmptyState, type EmptyStateProps } from './components/EmptyState';
+export { Container } from './components/Container';

--- a/ui/styles/base.css
+++ b/ui/styles/base.css
@@ -1,0 +1,103 @@
+/*
+ * Base layer — grounds the page in the tokens and enforces the
+ * responsive contract every RSC surface shares:
+ *   - 44px minimum touch targets on phones
+ *   - >=16px form text on mobile (stops iOS focus zoom)
+ *   - visible keyboard focus, invisible mouse focus
+ *   - safe-area utilities for notched devices
+ */
+
+html {
+  font-family: var(--font-sans);
+  overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: rgb(var(--background));
+  color: rgb(var(--foreground));
+  line-height: 1.6;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+  margin: 0;
+}
+
+code, kbd, pre, samp {
+  font-family: var(--font-mono);
+}
+
+/* Fluid heading scale — right-sized on a 375px phone and a 27" display */
+h1 { font-size: clamp(1.75rem, 1.2rem + 2.4vw, 2.75rem); font-weight: 700; }
+h2 { font-size: clamp(1.4rem, 1.05rem + 1.6vw, 2rem); font-weight: 700; }
+h3 { font-size: clamp(1.2rem, 1rem + 0.9vw, 1.5rem); font-weight: 600; }
+h4 { font-size: clamp(1.05rem, 0.95rem + 0.5vw, 1.25rem); font-weight: 600; }
+
+/* Keyboard focus is obvious; mouse focus is quiet */
+:focus-visible {
+  outline: 2px solid rgb(var(--ring));
+  outline-offset: 2px;
+}
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Thumb-friendly targets on phones */
+@media (max-width: 768px) {
+  button,
+  input,
+  select,
+  textarea,
+  a {
+    min-height: 44px;
+  }
+
+  /* iOS zooms any focused control under 16px — never give it the chance */
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  input[type='url'],
+  input[type='tel'],
+  input[type='search'],
+  input[type='number'],
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+/* Notch-aware padding helpers */
+.safe-top { padding-top: env(safe-area-inset-top); }
+.safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+.safe-left { padding-left: env(safe-area-inset-left); }
+.safe-right { padding-right: env(safe-area-inset-right); }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/ui/styles/components.css
+++ b/ui/styles/components.css
@@ -1,0 +1,422 @@
+/*
+ * Component classes — plain CSS on top of the tokens, no Tailwind required.
+ * The React components in @readysetcloud/ui render these classes; apps can
+ * also use them directly (including the Hugo site) for pixel-identical UI.
+ *
+ * Class names intentionally match what both dashboards already define
+ * (.btn-primary, .card, .input, ...) so migration is a delete, not a rename.
+ */
+
+/* ---------- buttons ---------- */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5625rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--surface)), 0 0 0 4px rgb(var(--ring));
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.btn-primary { background: rgb(var(--primary-600)); color: #fff; }
+.btn-primary:hover { background: rgb(var(--primary-700)); }
+
+.btn-secondary {
+  background: rgb(var(--secondary-100));
+  color: rgb(var(--secondary-900));
+  border-color: rgb(var(--border));
+}
+.btn-secondary:hover { background: rgb(var(--secondary-200)); }
+
+.btn-success { background: rgb(var(--success-600)); color: #fff; }
+.btn-success:hover { background: rgb(var(--success-700)); }
+
+.btn-warning { background: rgb(var(--warning-600)); color: #fff; }
+.btn-warning:hover { background: rgb(var(--warning-700)); }
+
+.btn-error { background: rgb(var(--error-600)); color: #fff; }
+.btn-error:hover { background: rgb(var(--error-700)); }
+
+.btn-ghost {
+  background: transparent;
+  color: rgb(var(--primary-700));
+  border-color: rgb(var(--border));
+}
+.btn-ghost:hover { background: rgb(var(--muted)); }
+
+.btn-sm { padding: 0.375rem 0.75rem; font-size: 0.8125rem; }
+.btn-lg { padding: 0.75rem 1.375rem; font-size: 1rem; }
+.btn-block { width: 100%; }
+
+/* ---------- inputs ---------- */
+
+.input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.5625rem 0.75rem;
+  background: rgb(var(--surface));
+  color: rgb(var(--foreground));
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.input::placeholder { color: rgb(var(--muted-foreground) / 0.8); }
+
+.input:focus-visible {
+  outline: none;
+  border-color: rgb(var(--primary-500));
+  box-shadow: 0 0 0 3px rgb(var(--primary-500) / 0.18);
+}
+
+.input:disabled {
+  background: rgb(var(--muted));
+  color: rgb(var(--muted-foreground));
+  cursor: not-allowed;
+}
+
+.input-error {
+  border-color: rgb(var(--error-500));
+}
+.input-error:focus-visible {
+  border-color: rgb(var(--error-500));
+  box-shadow: 0 0 0 3px rgb(var(--error-500) / 0.18);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.field-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: rgb(var(--foreground));
+}
+
+.field-hint {
+  font-size: 0.75rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.field-error {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgb(var(--error-600));
+}
+
+/* ---------- card ---------- */
+
+.card {
+  background: rgb(var(--surface));
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.card-header {
+  padding: 0.875rem 1.125rem;
+  border-bottom: 1px solid rgb(var(--border));
+}
+
+.card-title {
+  font-family: var(--font-display);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.card-description {
+  font-size: 0.8125rem;
+  color: rgb(var(--muted-foreground));
+  margin: 0.25rem 0 0;
+}
+
+.card-body {
+  padding: 1.125rem;
+}
+
+.card-footer {
+  padding: 0.75rem 1.125rem;
+  border-top: 1px solid rgb(var(--border));
+  background: rgb(var(--muted));
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+/* ---------- badge ---------- */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5625rem;
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.3;
+}
+
+.badge-primary { background: rgb(var(--primary-100)); color: rgb(var(--primary-700)); }
+.badge-success { background: rgb(var(--success-500) / 0.16); color: rgb(var(--success-600)); }
+.badge-warning { background: rgb(var(--warning-500) / 0.16); color: rgb(var(--warning-600)); }
+.badge-error { background: rgb(var(--error-500) / 0.16); color: rgb(var(--error-600)); }
+.badge-neutral { background: rgb(var(--muted)); color: rgb(var(--muted-foreground)); }
+
+/* ---------- alert ---------- */
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid;
+  font-size: 0.875rem;
+}
+
+.alert-error {
+  background: rgb(var(--error-50));
+  border-color: rgb(var(--error-200));
+  color: rgb(var(--error-600));
+}
+
+.alert-success {
+  background: rgb(var(--success-50));
+  border-color: rgb(var(--success-200));
+  color: rgb(var(--success-700));
+}
+
+.alert-info {
+  background: rgb(var(--primary-50));
+  border-color: rgb(var(--primary-200));
+  color: rgb(var(--primary-800));
+}
+
+/* ---------- spinner ---------- */
+
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: rsc-spin 0.7s linear infinite;
+  vertical-align: -0.125em;
+}
+
+@keyframes rsc-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ---------- skeleton ---------- */
+
+.skeleton {
+  border-radius: var(--radius);
+  background: linear-gradient(
+    90deg,
+    rgb(var(--muted)) 0%,
+    rgb(var(--muted) / 0.6) 50%,
+    rgb(var(--muted)) 100%
+  );
+  background-size: 200% 100%;
+  animation: rsc-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes rsc-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* ---------- modal (native <dialog>) ---------- */
+
+.modal {
+  padding: 0;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  color: rgb(var(--foreground));
+  box-shadow: var(--shadow-large);
+  width: min(28rem, calc(100vw - 2rem));
+  max-height: calc(100dvh - 2rem);
+}
+
+.modal::backdrop {
+  background: rgb(2 6 23 / 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.modal[open] {
+  animation: rsc-modal-in 0.18s ease-out;
+}
+
+@keyframes rsc-modal-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Full-width sheet on small screens — modern mobile pattern */
+@media (max-width: 640px) {
+  .modal {
+    width: 100vw;
+    max-width: none;
+    margin: auto 0 0;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
+/* ---------- toast ---------- */
+
+.toast-viewport {
+  position: fixed;
+  z-index: 100;
+  bottom: calc(1rem + env(safe-area-inset-bottom));
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: min(22rem, calc(100vw - 2rem));
+}
+
+@media (max-width: 640px) {
+  .toast-viewport {
+    left: 1rem;
+    right: 1rem;
+    max-width: none;
+  }
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgb(var(--border));
+  background: rgb(var(--surface));
+  color: rgb(var(--foreground));
+  box-shadow: var(--shadow-medium);
+  font-size: 0.875rem;
+  animation: rsc-toast-in 0.2s ease-out;
+}
+
+@keyframes rsc-toast-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+
+.toast-success { border-left: 3px solid rgb(var(--success-500)); }
+.toast-error { border-left: 3px solid rgb(var(--error-500)); }
+.toast-warning { border-left: 3px solid rgb(var(--warning-500)); }
+.toast-info { border-left: 3px solid rgb(var(--primary-500)); }
+
+/* ---------- empty state ---------- */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.empty-state-title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgb(var(--foreground));
+}
+
+/* ---------- container ---------- */
+
+.container-rsc {
+  width: 100%;
+  max-width: 72rem;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 4vw, 2rem);
+}
+
+/* ---------- auth card ---------- */
+
+.auth-card {
+  width: 100%;
+  max-width: 24rem;
+  margin-inline: auto;
+}
+
+.auth-card .card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.auth-subtitle {
+  font-size: 0.8125rem;
+  color: rgb(var(--muted-foreground));
+  margin: 0.25rem 0 0;
+}
+
+.auth-alt {
+  font-size: 0.8125rem;
+  color: rgb(var(--muted-foreground));
+  text-align: center;
+  margin: 0;
+}
+
+.auth-alt a,
+.auth-link {
+  color: rgb(var(--primary-700));
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.auth-alt a:hover,
+.auth-link:hover {
+  text-decoration: underline;
+}
+
+/* Verification code entry */
+.input-code {
+  font-family: var(--font-mono);
+  font-size: 1.125rem;
+  letter-spacing: 0.35em;
+  text-align: center;
+}

--- a/ui/styles/fonts.css
+++ b/ui/styles/fonts.css
@@ -1,0 +1,9 @@
+/*
+ * Brand fonts via Google Fonts. Optional import — readysetcloud.io already
+ * links these in its <head>; apps that don't can simply:
+ *
+ *   @import '@readysetcloud/ui/fonts.css';
+ *
+ * Raleway is loaded at wordmark weights only (logo lockups, --font-logo).
+ */
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Sora:wght@600;700;800&family=JetBrains+Mono:wght@400;600&family=Raleway:wght@700;800&display=swap');

--- a/ui/styles/index.css
+++ b/ui/styles/index.css
@@ -1,0 +1,11 @@
+/*
+ * @readysetcloud/ui — full stylesheet.
+ *
+ *   import '@readysetcloud/ui/styles.css';
+ *
+ * Fonts are NOT imported here (readysetcloud.io already links them);
+ * add `import '@readysetcloud/ui/fonts.css'` if your app doesn't.
+ */
+@import './tokens.css';
+@import './base.css';
+@import './components.css';

--- a/ui/styles/tokens.css
+++ b/ui/styles/tokens.css
@@ -1,0 +1,266 @@
+/*
+ * Ready, Set, Cloud — design tokens
+ * ---------------------------------
+ * The single source of truth for the shared brand across every RSC surface
+ * (newsletter dashboard, concurrency bootcamp platform, readysetcloud.io).
+ *
+ * Colors are RGB triplets so consumers can apply alpha:
+ *   color: rgb(var(--primary-500));
+ *   background: rgb(var(--primary-500) / 0.16);
+ *
+ * Brand decisions (2026-07):
+ *   - primary #219EFF (marketing azure), full generated ramp, 500 = brand hex
+ *   - error darkened to #C81E22 (deliberate move off the old rose)
+ *   - Sora = headings, Manrope = body, JetBrains Mono = data/code
+ *   - Raleway is the WORDMARK face only — never UI text (--font-logo)
+ *   - radius 4-6px: sharper than the old app look, not fully square
+ *
+ * Dark mode follows the same convention the apps already use:
+ *   system preference by default, explicit override via [data-theme].
+ */
+
+:root {
+  /* ---- ground (azure-biased neutrals) ---- */
+  --background: 247 250 252;
+  --surface: 255 255 255;
+  --foreground: 14 34 51;
+  --muted: 238 244 248;
+  --muted-foreground: 90 113 132;
+  --border: 220 230 238;
+  --ring: 33 158 255;
+
+  /* ---- primary: azure ramp generated from #219EFF ---- */
+  --primary-50: 235 246 255;
+  --primary-100: 214 236 255;
+  --primary-200: 173 217 255;
+  --primary-300: 124 194 255;
+  --primary-400: 78 174 255;
+  --primary-500: 33 158 255;  /* #219EFF — the brand color */
+  --primary-600: 11 130 230;
+  --primary-700: 6 104 184;
+  --primary-800: 10 84 144;
+  --primary-900: 14 70 116;
+  --primary-950: 8 43 74;
+
+  /* ---- secondary: slate ---- */
+  --secondary-50: 248 250 252;
+  --secondary-100: 241 245 249;
+  --secondary-200: 226 232 240;
+  --secondary-300: 203 213 225;
+  --secondary-400: 148 163 184;
+  --secondary-500: 100 116 139;
+  --secondary-600: 71 85 105;
+  --secondary-700: 51 65 85;
+  --secondary-800: 30 41 59;
+  --secondary-900: 15 23 42;
+  --secondary-950: 2 6 23;
+
+  /* ---- success: teal ---- */
+  --success-50: 236 253 248;
+  --success-100: 209 250 239;
+  --success-200: 167 243 223;
+  --success-300: 110 231 207;
+  --success-400: 52 211 191;
+  --success-500: 20 184 166;
+  --success-600: 15 143 127;
+  --success-700: 15 107 94;
+  --success-800: 15 83 72;
+  --success-900: 14 64 56;
+  --success-950: 7 39 35;
+
+  /* ---- warning: orange ---- */
+  --warning-50: 255 247 237;
+  --warning-100: 255 237 213;
+  --warning-200: 254 215 170;
+  --warning-300: 253 186 116;
+  --warning-400: 251 146 60;
+  --warning-500: 249 115 22;
+  --warning-600: 234 88 12;
+  --warning-700: 194 65 12;
+  --warning-800: 154 52 18;
+  --warning-900: 124 45 18;
+  --warning-950: 67 20 7;
+
+  /* ---- error: deep red ramp around #C81E22 ---- */
+  --error-50: 253 235 235;
+  --error-100: 250 214 214;
+  --error-200: 244 173 174;
+  --error-300: 235 128 130;
+  --error-400: 219 77 80;
+  --error-500: 200 30 34;    /* #C81E22 */
+  --error-600: 159 18 22;
+  --error-700: 130 15 18;
+  --error-800: 106 14 17;
+  --error-900: 88 15 17;
+  --error-950: 48 6 8;
+
+  /* ---- shape: sharper, not square ---- */
+  --radius-sm: 2px;
+  --radius: 4px;
+  --radius-lg: 6px;
+  --radius-xl: 8px;
+  --radius-full: 999px;
+
+  /* ---- elevation ---- */
+  --shadow-soft: 0 1px 2px rgb(14 34 51 / 0.06), 0 4px 16px -6px rgb(14 34 51 / 0.12);
+  --shadow-medium: 0 4px 24px -8px rgb(14 34 51 / 0.18);
+  --shadow-large: 0 10px 40px -10px rgb(14 34 51 / 0.25);
+
+  /* ---- typography ---- */
+  --font-display: 'Sora', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-sans: 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Consolas, monospace;
+  --font-logo: 'Raleway', var(--font-display); /* wordmark lockups only */
+}
+
+/* Dark ground + inverted ramps. Two blocks, same values: system preference
+   (unless an explicit theme is set) and explicit [data-theme="dark"]. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --background: 6 20 32;
+    --surface: 14 34 51;
+    --foreground: 226 236 243;
+    --muted: 20 41 58;
+    --muted-foreground: 140 166 184;
+    --border: 36 65 85;
+    --ring: 78 174 255;
+
+    --primary-50: 8 43 74;
+    --primary-100: 14 70 116;
+    --primary-200: 10 84 144;
+    --primary-300: 6 104 184;
+    --primary-400: 11 130 230;
+    --primary-500: 33 158 255;
+    --primary-600: 78 174 255;
+    --primary-700: 124 194 255;
+    --primary-800: 173 217 255;
+    --primary-900: 214 236 255;
+    --primary-950: 235 246 255;
+
+    --secondary-50: 2 6 23;
+    --secondary-100: 15 23 42;
+    --secondary-200: 30 41 59;
+    --secondary-300: 51 65 85;
+    --secondary-400: 71 85 105;
+    --secondary-500: 100 116 139;
+    --secondary-600: 148 163 184;
+    --secondary-700: 203 213 225;
+    --secondary-800: 226 232 240;
+    --secondary-900: 241 245 249;
+    --secondary-950: 248 250 252;
+
+    --success-50: 7 39 35;
+    --success-100: 14 64 56;
+    --success-200: 15 83 72;
+    --success-300: 15 107 94;
+    --success-400: 15 143 127;
+    --success-500: 20 184 166;
+    --success-600: 52 211 191;
+    --success-700: 110 231 207;
+    --success-800: 167 243 223;
+    --success-900: 209 250 239;
+    --success-950: 236 253 248;
+
+    --warning-50: 67 20 7;
+    --warning-100: 124 45 18;
+    --warning-200: 154 52 18;
+    --warning-300: 194 65 12;
+    --warning-400: 234 88 12;
+    --warning-500: 249 115 22;
+    --warning-600: 251 146 60;
+    --warning-700: 253 186 116;
+    --warning-800: 254 215 170;
+    --warning-900: 255 237 213;
+    --warning-950: 255 247 237;
+
+    --error-50: 48 6 8;
+    --error-100: 88 15 17;
+    --error-200: 106 14 17;
+    --error-300: 130 15 18;
+    --error-400: 159 18 22;
+    --error-500: 219 77 80;
+    --error-600: 235 128 130;
+    --error-700: 244 173 174;
+    --error-800: 250 214 214;
+    --error-900: 253 235 235;
+    --error-950: 253 235 235;
+
+    --shadow-soft: 0 1px 2px rgb(0 0 0 / 0.4), 0 4px 16px -6px rgb(0 0 0 / 0.5);
+    --shadow-medium: 0 4px 24px -8px rgb(0 0 0 / 0.6);
+    --shadow-large: 0 10px 40px -10px rgb(0 0 0 / 0.7);
+  }
+}
+
+:root[data-theme='dark'] {
+  --background: 6 20 32;
+  --surface: 14 34 51;
+  --foreground: 226 236 243;
+  --muted: 20 41 58;
+  --muted-foreground: 140 166 184;
+  --border: 36 65 85;
+  --ring: 78 174 255;
+
+  --primary-50: 8 43 74;
+  --primary-100: 14 70 116;
+  --primary-200: 10 84 144;
+  --primary-300: 6 104 184;
+  --primary-400: 11 130 230;
+  --primary-500: 33 158 255;
+  --primary-600: 78 174 255;
+  --primary-700: 124 194 255;
+  --primary-800: 173 217 255;
+  --primary-900: 214 236 255;
+  --primary-950: 235 246 255;
+
+  --secondary-50: 2 6 23;
+  --secondary-100: 15 23 42;
+  --secondary-200: 30 41 59;
+  --secondary-300: 51 65 85;
+  --secondary-400: 71 85 105;
+  --secondary-500: 100 116 139;
+  --secondary-600: 148 163 184;
+  --secondary-700: 203 213 225;
+  --secondary-800: 226 232 240;
+  --secondary-900: 241 245 249;
+  --secondary-950: 248 250 252;
+
+  --success-50: 7 39 35;
+  --success-100: 14 64 56;
+  --success-200: 15 83 72;
+  --success-300: 15 107 94;
+  --success-400: 15 143 127;
+  --success-500: 20 184 166;
+  --success-600: 52 211 191;
+  --success-700: 110 231 207;
+  --success-800: 167 243 223;
+  --success-900: 209 250 239;
+  --success-950: 236 253 248;
+
+  --warning-50: 67 20 7;
+  --warning-100: 124 45 18;
+  --warning-200: 154 52 18;
+  --warning-300: 194 65 12;
+  --warning-400: 234 88 12;
+  --warning-500: 249 115 22;
+  --warning-600: 251 146 60;
+  --warning-700: 253 186 116;
+  --warning-800: 254 215 170;
+  --warning-900: 255 237 213;
+  --warning-950: 255 247 237;
+
+  --error-50: 48 6 8;
+  --error-100: 88 15 17;
+  --error-200: 106 14 17;
+  --error-300: 130 15 18;
+  --error-400: 159 18 22;
+  --error-500: 219 77 80;
+  --error-600: 235 128 130;
+  --error-700: 244 173 174;
+  --error-800: 250 214 214;
+  --error-900: 253 235 235;
+  --error-950: 253 235 235;
+
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 0.4), 0 4px 16px -6px rgb(0 0 0 / 0.5);
+  --shadow-medium: 0 4px 24px -8px rgb(0 0 0 / 0.6);
+  --shadow-large: 0 10px 40px -10px rgb(0 0 0 / 0.7);
+}

--- a/ui/tailwind-preset.cjs
+++ b/ui/tailwind-preset.cjs
@@ -1,0 +1,101 @@
+/**
+ * Tailwind preset for Ready, Set, Cloud apps.
+ *
+ * tailwind.config.js:
+ *   module.exports = {
+ *     presets: [require('@readysetcloud/ui/tailwind-preset')],
+ *     content: [
+ *       './index.html',
+ *       './src/** /*.{ts,tsx}',
+ *       './node_modules/@readysetcloud/ui/dist/** /*.js'
+ *     ]
+ *   };
+ *
+ * Every color resolves through the CSS variables in tokens.css, so light/dark
+ * and any future brand shifts come from the package — never app configs.
+ */
+
+const withVar = (name) => {
+  const scale = {};
+  for (const stop of [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]) {
+    scale[stop] = `rgb(var(--${name}-${stop}) / <alpha-value>)`;
+  }
+  return scale;
+};
+
+const primary = withVar('primary');
+const secondary = withVar('secondary');
+const success = withVar('success');
+const warning = withVar('warning');
+const error = withVar('error');
+
+module.exports = {
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        primary,
+        secondary,
+        success,
+        warning,
+        error,
+        background: 'rgb(var(--background) / <alpha-value>)',
+        surface: 'rgb(var(--surface) / <alpha-value>)',
+        foreground: 'rgb(var(--foreground) / <alpha-value>)',
+        muted: {
+          DEFAULT: 'rgb(var(--muted) / <alpha-value>)',
+          foreground: 'rgb(var(--muted-foreground) / <alpha-value>)'
+        },
+        border: 'rgb(var(--border) / <alpha-value>)',
+        ring: 'rgb(var(--ring) / <alpha-value>)',
+
+        // semantic aliases so existing utility usage keeps working
+        blue: primary,
+        green: success,
+        teal: success,
+        red: error,
+        rose: error,
+        orange: warning,
+        amber: warning,
+        yellow: warning,
+        gray: secondary,
+        slate: secondary
+      },
+      fontFamily: {
+        display: ['Sora', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: ['Manrope', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'Consolas', 'monospace'],
+        logo: ['Raleway', 'Sora', 'sans-serif'] // wordmark lockups only
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius)',
+        md: 'var(--radius)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)'
+      },
+      boxShadow: {
+        soft: 'var(--shadow-soft)',
+        medium: 'var(--shadow-medium)',
+        large: 'var(--shadow-large)'
+      },
+      screens: {
+        xs: '400px'
+      },
+      animation: {
+        'fade-in': 'rsc-fade-in 0.3s ease-in-out',
+        'slide-up': 'rsc-slide-up 0.3s ease-out'
+      },
+      keyframes: {
+        'rsc-fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' }
+        },
+        'rsc-slide-up': {
+          from: { opacity: '0', transform: 'translateY(10px)' },
+          to: { opacity: '1', transform: 'translateY(0)' }
+        }
+      }
+    }
+  }
+};

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/ui/tsup.config.ts
+++ b/ui/tsup.config.ts
@@ -1,14 +1,29 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    'auth/index': 'src/auth/index.ts'
+export default defineConfig([
+  // npm package build (React apps import from node_modules)
+  {
+    entry: {
+      index: 'src/index.ts',
+      'auth/index': 'src/auth/index.ts'
+    },
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    external: ['react', 'react-dom', 'react/jsx-runtime'],
+    target: 'es2022'
   },
-  format: ['esm'],
-  dts: true,
-  sourcemap: true,
-  clean: true,
-  external: ['react', 'react-dom', 'react/jsx-runtime'],
-  target: 'es2022'
-});
+  // browser bundles (script-tag consumers via the assets bucket —
+  // same model as Amplify's hosted UI assets)
+  {
+    entry: { auth: 'src/auth/browser.ts' },
+    outDir: 'dist/browser',
+    format: ['esm', 'iife'],
+    globalName: 'rscAuth',
+    minify: true,
+    sourcemap: true,
+    target: 'es2020',
+    platform: 'browser'
+  }
+]);

--- a/ui/tsup.config.ts
+++ b/ui/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'auth/index': 'src/auth/index.ts'
+  },
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
+  target: 'es2022'
+});

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}']
+  }
+});


### PR DESCRIPTION
## What

New `ui/` package — `@readysetcloud/ui` — the shared design system converging the newsletter dashboard, the concurrency bootcamp platform, and readysetcloud.io onto one brand, one component kit, and one auth layer. This PR only adds the package to rsc-core; wiring the apps comes in follow-up PRs per repo.

## The brand

Approved via design preview (v0.3):

| Layer | Decision |
| --- | --- |
| Primary | `#219EFF` azure (marketing brand) — generated 50–950 ramp + dark-mode inversion |
| Error | Darkened to `#C81E22` (off the old rose/pink) |
| Type | Sora headings · Manrope body · JetBrains Mono data — **Raleway reserved for the wordmark only** (`--font-logo`) |
| Shape | 4–6px radius — sharper than the old app look, not fully square |
| Responsive | 44px touch targets, fluid `clamp()` type, safe-area insets, ≥16px mobile inputs — enforced in the base layer |

## Architecture

- **`styles/`** — tokens as CSS variables + plain-CSS component classes (`.btn-primary`, `.card`, `.input`…) using the **same class names both dashboards already define**, so migration is deletion, not renaming. No Tailwind/React required → the Hugo site can consume the identical brand.
- **`tailwind-preset.cjs`** — for app-authored UI; every color resolves through the token variables. Semantic aliases (`blue`→primary, `red`→error, `gray`→secondary) keep existing utilities working during migration.
- **React components** — Button, Input/PasswordInput/CodeInput, TextArea, Select, Card family, Badge, Alert, Modal (native `<dialog>`, bottom-sheet on mobile), Toast, Spinner, Skeleton, EmptyState, Container. Zero runtime deps beyond React.
- **`/auth`** — the dependency-free fetch-based Cognito core promoted from concurrency-bootcamp (same `rsc:auth` session contract), with `configureAuth()` injection instead of a hard-coded config fetch; `AuthProvider`/`useAuth`/`RequireAuth` (router-agnostic); prebuilt Login/SignUp+confirm/ForgotPassword flows. ~25KB unminified — replaces newsletter's `aws-amplify` dependency when it migrates.

## Reviewer notes

- **Password policy fix baked in:** the pool (template.yaml `PasswordPolicy`) requires 8+/upper/lower/number with `RequireSymbols: false`. Newsletter's current UI copy claims symbols are required — the shared validation encodes the real policy.
- **SSO caveat documented:** the `rsc:auth` localStorage contract shares sessions per-origin. True cross-subdomain SSO needs a `.readysetcloud.io` parent-domain cookie — deliberately out of scope, tracked for a future change (the pool's existing `authenticate.<domain>` custom domain is a ready anchor).
- Publishing targets GitHub Packages (`publishConfig` set); no release workflow yet — can add on merge if wanted.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — **20/20 passing** (session contract, token refresh incl. offline-keeps-tokens, error translation, password policy)
- `npx tsup` build green (ESM + `.d.ts`)
- Root `npm run lint` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)