### PR TITLE
Use npm Trusted Publishing instead of a token secret

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,16 +15,39 @@ env:
   BRANCH_NAME: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event_name == 'push' && github.ref }}
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'template.yaml'
+              - 'samconfig.toml'
+              - 'functions/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/deploy.yaml'
+            ui:
+              - 'ui/**'
+              - 'scripts/publish-ui-assets.mjs'
+              - '.github/workflows/deploy.yaml'
+
   predeploy-validations:
     name: Pre-deploy validations
     uses: ./.github/workflows/pre-deploy-validation.yaml
 
   deploy:
-    name: Deploy
+    name: Deploy backend (SAM)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # npm Trusted Publishing (OIDC)
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS
@@ -49,13 +72,30 @@ jobs:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --parameter-overrides UpdateGitHubSourceCode=true DefaultCacheName=readysetcloud BucketName=readysetcloud AmplifyAppId=${{ secrets.PROD_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }} RootDomainName=readysetcloud.io HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
 
-      - name: Setup Node for npm publish
-        uses: actions/setup-node@v4
+  publish-ui:
+    name: Publish UI package
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.ui == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # npm Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.PROD_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.PROD_SECRET_KEY }}
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Publish UI hosted assets
+      - name: Build and publish hosted assets
         run: |
+          npm ci
           cd ui
           npm ci
           npm test

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS
@@ -50,7 +53,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Publish UI hosted assets
         run: |
@@ -61,11 +63,13 @@ jobs:
           cd ..
           node scripts/publish-ui-assets.mjs --bucket readysetcloud
 
+      # Auth is npm Trusted Publishing (OIDC via id-token: write) — no npm
+      # token secret. The trusted publisher on npmjs.com must point at this
+      # repo + deploy.yaml. Requires a recent npm CLI for OIDC support.
       - name: Publish @readysetcloud/ui to npm
         working-directory: ui
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          npm install -g npm@latest
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@readysetcloud/ui@$VERSION" version > /dev/null 2>&1; then
             echo "@readysetcloud/ui@$VERSION already on npm — skipping publish"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,14 +16,40 @@ env:
   BRANCH_NAME: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event_name == 'pull_request' && github.head_ref }}
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'template.yaml'
+              - 'samconfig.toml'
+              - 'functions/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/pull-request.yaml'
+            ui:
+              - 'ui/**'
+              - 'scripts/publish-ui-assets.mjs'
+              - '.github/workflows/pull-request.yaml'
+
   predeploy-validations:
     name: Pre-deploy validations
     uses: ./.github/workflows/pre-deploy-validation.yaml
 
   deploy:
-    name: Deploy
+    name: Deploy backend (SAM)
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: changes
+    if: ${{ github.actor != 'dependabot[bot]' && needs.changes.outputs.backend == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS
@@ -48,8 +74,27 @@ jobs:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
 
-      - name: Publish UI hosted assets
+  publish-ui:
+    name: Publish UI hosted assets (stage)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.actor != 'dependabot[bot]' && needs.changes.outputs.ui == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.STAGE_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.STAGE_SECRET_KEY }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build and publish hosted assets
         run: |
+          npm ci
           cd ui
           npm ci
           npm test


### PR DESCRIPTION
## What

Follow-up to #177: switches the npm publish step from a stored `NPM_TOKEN` automation token to **npm Trusted Publishing** (OIDC), per npm's guidance that 2FA-bypassing automation tokens are a security risk for CI/CD.

- `deploy` job gets `permissions: id-token: write`; npm verifies the workflow's identity per-run
- No npm token secret to create, rotate, or leak
- Provenance attestations generated automatically (verified "built from this repo" badge on the npm package page)
- Upgrades npm CLI in the publish step (OIDC support needs a recent version)

## Setup required before this can publish (one-time, manual)

1. Create the `readysetcloud` org on npmjs.com (if it doesn't exist)
2. First publish must be local — trusted-publisher config lives in package settings, so the package must exist: `cd ui && npm ci && npm run build && npm publish`
3. npmjs.com → `@readysetcloud/ui` → Settings → Trusted Publisher → GitHub Actions → `readysetcloud` / `rsc-core` / workflow `deploy.yaml` (environment blank)
4. Optional hardening: set the package to "Require trusted publisher" so tokens can't publish at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)