### PR TITLE
feat(ui): add side (vertical) layout option to AppNav

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -108,6 +108,10 @@ Navbar rules:
   the vanilla build) and `section` (heading — consecutive same-section items are
   grouped; ungrouped items stay in place). Sections are ignored in `top`. The
   rail collapses to the shared hamburger drawer on mobile.
+- `linkComponent` (React only) routes in-app links (brand, nav items, primary
+  action, auth actions) through your router's link for client-side navigation —
+  `({ href, ...props }) => <Link to={href} {...props} />`. External items always
+  fall back to a plain anchor. The vanilla build always emits anchors.
 - `authState="none"` hides all auth controls. `authState="anonymous"` shows
   sign-in/sign-up controls. `authState="authenticated"` shows the profile menu.
 - Auth URLs default to `/login`, `/signup`, and `/logout`; override with

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -72,7 +72,7 @@ All components are typed, accept `className`, and forward standard HTML props.
 | `Skeleton` | `width`, `height` | Shimmer placeholder. |
 | `EmptyState` | `title`, `description?`, `icon?`, `action?` | |
 | `Container` | div props | max 72rem, fluid padding. |
-| `AppNav` | `appName`, `navItems`, `currentServiceId`, `authState`, `services`, auth actions | Shared top navbar: hardcoded ReadySetCloud cloud mark, configurable Raleway app name, Manrope nav labels, theme toggle, authenticated-only 9-box app launcher, optional auth controls. |
+| `AppNav` | `appName`, `navItems`, `layout`, `currentServiceId`, `authState`, `services`, auth actions | Shared navbar: hardcoded ReadySetCloud cloud mark, configurable Raleway app name, Manrope nav labels, theme toggle, authenticated-only 9-box app launcher, optional auth controls. `layout="side"` renders a vertical rail (per-item `icon` + grouped `section` headings); default `top` is the horizontal bar. |
 | `cx(...parts)` | | Classname join helper (replaces clsx for simple cases). |
 
 ## Shared navbar and app registry
@@ -103,6 +103,11 @@ Navbar rules:
 - `navItems` are app-specific. Use `visible: false` for simple gating and
   `active: true` for the current route. The shared app launcher active state is
   driven by `currentServiceId`.
+- `layout="side"` renders a vertical 16rem rail instead of the top bar; it
+  reads the same `navItems` plus per-item `icon` (a node; an HTML/SVG string for
+  the vanilla build) and `section` (heading — consecutive same-section items are
+  grouped; ungrouped items stay in place). Sections are ignored in `top`. The
+  rail collapses to the shared hamburger drawer on mobile.
 - `authState="none"` hides all auth controls. `authState="anonymous"` shows
   sign-in/sign-up controls. `authState="authenticated"` shows the profile menu.
 - Auth URLs default to `/login`, `/signup`, and `/logout`; override with

--- a/ui/README.md
+++ b/ui/README.md
@@ -228,6 +228,29 @@ pinned). Below the mobile breakpoint it collapses to the same hamburger drawer
 as the top bar. Active / hover / highlight states are themed from the shared
 tokens in both light and dark.
 
+### Client-side routing (`linkComponent`)
+
+By default `AppNav` renders plain `<a>` anchors, which trigger a full-page
+reload in an SPA. Pass `linkComponent` to render in-app links (brand, nav items,
+primary action, auth actions) through your router's link so navigation stays
+client-side. `AppNav` always passes the target as `href` — adapt it to your
+router's own prop:
+
+```tsx
+import { Link } from 'react-router-dom';
+
+<AppNav
+  appName="Outboxed"
+  layout="side"
+  linkComponent={({ href, ...props }) => <Link to={href} {...props} />}
+  navItems={/* … */}
+/>;
+```
+
+External items (`external: true`) always fall back to a real anchor with
+`target="_blank"` — a router link can't own a cross-origin navigation. This is
+React-only; the vanilla `mountAppNav` build always emits anchors.
+
 Auth controls are explicit:
 
 ```tsx

--- a/ui/README.md
+++ b/ui/README.md
@@ -116,7 +116,7 @@ hand-rolled headers, one source of truth.
 ```
 
 `mountAppNav(target, options)` takes the same options as the React `<AppNav>`
-(`appName`, `navItems`, `primaryAction`, `services`, `currentServiceId`,
+(`appName`, `navItems`, `layout`, `primaryAction`, `services`, `currentServiceId`,
 `user`, `authState`, `signInAction`/`signUpAction`/`signOutAction`, `theme`,
 `onThemeChange`/`onProfileClick`/`onSignOut`, …) and returns a handle with
 `update(partialOptions)`, `setTheme(theme)`, `getTheme()`, and `destroy()`. The
@@ -190,6 +190,43 @@ The default app manifest includes:
 
 The 9-box app launcher is shown only for authenticated users and only when at
 least one service is visible.
+
+### Vertical side-nav layout
+
+Pass `layout="side"` to render the same nav as a vertical rail instead of a top
+bar. It shares the brand mark, theme toggle, app launcher, and profile menu, and
+reads the same `navItems` API — with two extra per-item capabilities used by the
+side layout:
+
+- `icon` — a leading icon (a React node; an HTML/SVG markup string for the
+  vanilla `mountAppNav`).
+- `section` — a heading. Consecutive items sharing a `section` are grouped under
+  one label; items without a section render as a headingless run, so a
+  standalone item stays put at the top or bottom of the rail. (Sections are
+  ignored in the `top` layout.)
+
+```tsx
+<AppNav
+  appName="Outboxed"
+  layout="side"
+  authState="authenticated"
+  user={{ name: user.name, email: user.email }}
+  navItems={[
+    { id: '/', label: 'Dashboard', href: '/', icon: <HomeIcon />, active: true },
+    { id: '/issues', label: 'Issues', href: '/issues', icon: <IssuesIcon />, section: 'Publish' },
+    { id: '/subscribers', label: 'Subscribers', href: '/subscribers', icon: <UsersIcon />, section: 'Publish' },
+    { id: '/posts', label: 'Posts', href: '/posts', icon: <PostsIcon />, section: 'Content' },
+    { id: '/sponsors', label: 'Sponsors', href: '/sponsors', icon: <MoneyIcon />, section: 'Monetization' },
+    { id: '/brand', label: 'Brand', href: '/brand', icon: <BrandIcon /> }
+  ]}
+/>;
+```
+
+The rail is a fixed 16rem-wide, full-height column — place it in a flex/grid row
+beside your content (add `position: sticky; top: 0` yourself if you want it
+pinned). Below the mobile breakpoint it collapses to the same hamburger drawer
+as the top bar. Active / hover / highlight states are themed from the shared
+tokens in both light and dark.
 
 Auth controls are explicit:
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/ui",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
   "license": "MIT",
   "type": "module",

--- a/ui/src/components/AppNav.test.tsx
+++ b/ui/src/components/AppNav.test.tsx
@@ -1,0 +1,57 @@
+/* Tests for the React AppNav side (vertical) layout: grouped sections, per-item
+   icons, and that the default top layout stays flat. The vanilla build has its
+   own parity tests in nav-browser.test.ts. */
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AppNav, type AppNavItem } from './AppNav';
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+const sideItems: AppNavItem[] = [
+  { id: '/', label: 'Dashboard', href: '/', active: true, icon: <svg data-testid="home" /> },
+  { id: '/issues', label: 'Issues', href: '/issues', section: 'Publish' },
+  { id: '/subscribers', label: 'Subscribers', href: '/subscribers', section: 'Publish' },
+  { id: '/posts', label: 'Posts', href: '/posts', section: 'Content' },
+  { id: '/brand', label: 'Brand', href: '/brand' }
+];
+
+describe('AppNav side layout', () => {
+  it('adds app-nav-side and groups consecutive sections, preserving order', () => {
+    const { container } = render(<AppNav appName="Outboxed" layout="side" navItems={sideItems} />);
+
+    expect(container.querySelector('.app-nav')?.classList.contains('app-nav-side')).toBe(true);
+
+    const sections = [...container.querySelectorAll('.app-nav-section')];
+    expect(sections).toHaveLength(4);
+    const titles = sections.map((s) => s.querySelector('.app-nav-section-title')?.textContent ?? null);
+    expect(titles).toEqual([null, 'Publish', 'Content', null]);
+
+    const publishLinks = [...sections[1]!.querySelectorAll('.app-nav-link')].map((l) => l.textContent);
+    expect(publishLinks).toEqual(['Issues', 'Subscribers']);
+  });
+
+  it('renders the per-item icon and marks the active item with aria-current', () => {
+    const { container } = render(<AppNav appName="Outboxed" layout="side" navItems={sideItems} />);
+    const active = container.querySelector('.app-nav-link-active') as HTMLElement;
+    expect(active.textContent).toBe('Dashboard');
+    expect(active.getAttribute('aria-current')).toBe('page');
+    expect(active.querySelector('.app-nav-link-icon svg[data-testid="home"]')).toBeTruthy();
+  });
+
+  it('stays flat with no sections in the default top layout', () => {
+    const { container } = render(<AppNav appName="RSC" navItems={sideItems} />);
+    expect(container.querySelector('.app-nav')?.classList.contains('app-nav-side')).toBe(false);
+    expect(container.querySelector('.app-nav-section')).toBeNull();
+    expect([...container.querySelectorAll('.app-nav-link')].map((l) => l.textContent)).toEqual([
+      'Dashboard',
+      'Issues',
+      'Subscribers',
+      'Posts',
+      'Brand'
+    ]);
+  });
+});

--- a/ui/src/components/AppNav.test.tsx
+++ b/ui/src/components/AppNav.test.tsx
@@ -4,7 +4,7 @@
 
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { AppNav, type AppNavItem } from './AppNav';
+import { AppNav, type AppNavItem, type AppNavLinkProps } from './AppNav';
 
 afterEach(() => {
   cleanup();
@@ -40,6 +40,47 @@ describe('AppNav side layout', () => {
     expect(active.textContent).toBe('Dashboard');
     expect(active.getAttribute('aria-current')).toBe('page');
     expect(active.querySelector('.app-nav-link-icon svg[data-testid="home"]')).toBeTruthy();
+  });
+
+  it('routes in-app links through linkComponent but leaves external links as anchors', () => {
+    const seen: string[] = [];
+    // A stand-in for a router Link: records the target and marks itself so the
+    // test can tell it apart from a plain anchor.
+    const RouterLink = ({ href, children, ...rest }: AppNavLinkProps) => {
+      seen.push(href);
+      return (
+        <a data-router="1" href={href} {...rest}>
+          {children}
+        </a>
+      );
+    };
+
+    const { container } = render(
+      <AppNav
+        appName="Outboxed"
+        layout="side"
+        linkComponent={RouterLink}
+        primaryAction={{ label: 'New issue', href: '/issues/new' }}
+        navItems={[
+          { id: '/', label: 'Dashboard', href: '/', active: true },
+          { id: 'blog', label: 'Blog', href: 'https://readysetcloud.io', external: true }
+        ]}
+      />
+    );
+
+    // Brand, internal nav item, and primary action go through the router link.
+    expect(seen).toContain('/');
+    expect(seen).toContain('/issues/new');
+
+    const internal = container.querySelector('.app-nav-link[href="/"]') as HTMLElement;
+    expect(internal.getAttribute('data-router')).toBe('1');
+    expect(internal.getAttribute('aria-current')).toBe('page');
+
+    // The external link stays a real anchor (target/rel), not a router link.
+    const external = container.querySelector('.app-nav-link[href="https://readysetcloud.io"]') as HTMLElement;
+    expect(external.getAttribute('data-router')).toBeNull();
+    expect(external.getAttribute('target')).toBe('_blank');
+    expect(external.getAttribute('rel')).toBe('noreferrer');
   });
 
   it('stays flat with no sections in the default top layout', () => {

--- a/ui/src/components/AppNav.tsx
+++ b/ui/src/components/AppNav.tsx
@@ -7,6 +7,7 @@ import { cx } from './cx';
 
 export type AppTheme = 'light' | 'dark' | 'system';
 export type AppNavAuthState = 'none' | 'anonymous' | 'authenticated';
+export type AppNavLayout = 'top' | 'side';
 
 export interface AppNavUser {
   name?: string;
@@ -22,6 +23,13 @@ export interface AppNavItem {
   external?: boolean;
   highlight?: boolean;
   visible?: boolean;
+  /** Optional leading icon (e.g. an SVG element). Rendered before the label. */
+  icon?: ReactNode;
+  /**
+   * Optional section heading. Consecutive items sharing a section are grouped
+   * under one heading in the `side` layout (ignored in the `top` layout).
+   */
+  section?: string;
 }
 
 export interface AppNavAction {
@@ -38,6 +46,8 @@ export interface AppNavProps {
   services?: readonly RscService[];
   currentServiceId?: string;
   homeHref?: string;
+  /** `top` (default) renders the horizontal bar; `side` renders a vertical rail. */
+  layout?: AppNavLayout;
   user?: AppNavUser;
   authState?: AppNavAuthState;
   signInAction?: AppNavAction;
@@ -60,6 +70,7 @@ export function AppNav({
   services = readySetCloudServices,
   currentServiceId,
   homeHref = '/',
+  layout = 'top',
   user,
   authState,
   signInAction,
@@ -81,6 +92,8 @@ export function AppNav({
   const selectedTheme = theme ?? uncontrolledTheme;
   const visibleServices = useMemo(() => getVisibleServices(services), [services]);
   const visibleNavItems = useMemo(() => navItems.filter((item) => item.visible !== false), [navItems]);
+  const navGroups = useMemo(() => groupNavItems(visibleNavItems), [visibleNavItems]);
+  const isSide = layout === 'side';
   const resolvedAuthState = authState ?? (user ? 'authenticated' : 'none');
   const showAuthenticatedControls = resolvedAuthState === 'authenticated';
   const showAnonymousControls = resolvedAuthState === 'anonymous';
@@ -108,7 +121,7 @@ export function AppNav({
 
   return (
     <>
-      <header className={cx('app-nav', className)}>
+      <header className={cx('app-nav', isSide && 'app-nav-side', className)}>
         <div className="app-nav-inner">
           <a className="app-nav-brand" href={homeHref}>
             <span className="app-nav-brand-mark" aria-hidden="true" />
@@ -128,21 +141,16 @@ export function AppNav({
           <div className={cx('app-nav-collapse', mobileNavOpen && 'app-nav-collapse-open')}>
             {visibleNavItems.length > 0 && (
               <nav className="app-nav-links" aria-label="Primary navigation">
-                {visibleNavItems.map((item) => (
-                  <a
-                    key={item.id}
-                    className={cx(
-                      'app-nav-link',
-                      item.active && 'app-nav-link-active',
-                      item.highlight && 'app-nav-link-highlight'
-                    )}
-                    href={item.href}
-                    target={item.external ? '_blank' : undefined}
-                    rel={item.external ? 'noreferrer' : undefined}
-                  >
-                    {item.label}
-                  </a>
-                ))}
+                {isSide
+                  ? navGroups.map((group, index) => (
+                      <div className="app-nav-section" key={group.section ?? `__ungrouped-${index}`}>
+                        {group.section && <span className="app-nav-section-title">{group.section}</span>}
+                        {group.items.map((item) => (
+                          <AppNavLink key={item.id} item={item} />
+                        ))}
+                      </div>
+                    ))
+                  : visibleNavItems.map((item) => <AppNavLink key={item.id} item={item} />)}
               </nav>
             )}
 
@@ -265,6 +273,49 @@ export function AppNav({
         </Modal>
       )}
     </>
+  );
+}
+
+interface AppNavGroup {
+  section?: string;
+  items: AppNavItem[];
+}
+
+/**
+ * Collapse a flat item list into consecutive runs sharing a `section`. This
+ * preserves the caller's order, so ungrouped items stay where they are (e.g. a
+ * standalone "Dashboard" at the top and "Brand" at the bottom of a side rail).
+ */
+function groupNavItems(items: readonly AppNavItem[]): AppNavGroup[] {
+  const groups: AppNavGroup[] = [];
+  for (const item of items) {
+    const last = groups[groups.length - 1];
+    if (last && last.section === item.section) last.items.push(item);
+    else groups.push({ section: item.section, items: [item] });
+  }
+  return groups;
+}
+
+function AppNavLink({ item }: { item: AppNavItem }) {
+  return (
+    <a
+      className={cx(
+        'app-nav-link',
+        item.active && 'app-nav-link-active',
+        item.highlight && 'app-nav-link-highlight'
+      )}
+      href={item.href}
+      aria-current={item.active ? 'page' : undefined}
+      target={item.external ? '_blank' : undefined}
+      rel={item.external ? 'noreferrer' : undefined}
+    >
+      {item.icon && (
+        <span className="app-nav-link-icon" aria-hidden="true">
+          {item.icon}
+        </span>
+      )}
+      {item.label}
+    </a>
   );
 }
 

--- a/ui/src/components/AppNav.tsx
+++ b/ui/src/components/AppNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from 'react';
 import { getVisibleServices, readySetCloudServices, type RscService } from '../services/registry';
 import { Badge } from './Badge';
 import { Button } from './Button';
@@ -39,6 +39,20 @@ export interface AppNavAction {
   external?: boolean;
 }
 
+/**
+ * Props passed to a custom `linkComponent`. Mirrors the anchor attributes
+ * `AppNav` would otherwise set, with `href` as the target — map it to your
+ * router's own prop (e.g. React Router: `({ href, ...rest }) => <Link to={href} {...rest} />`).
+ */
+export interface AppNavLinkProps {
+  href: string;
+  className?: string;
+  children: ReactNode;
+  'aria-current'?: 'page';
+}
+
+export type AppNavLinkComponent = ComponentType<AppNavLinkProps>;
+
 export interface AppNavProps {
   appName: string;
   navItems?: readonly AppNavItem[];
@@ -48,6 +62,12 @@ export interface AppNavProps {
   homeHref?: string;
   /** `top` (default) renders the horizontal bar; `side` renders a vertical rail. */
   layout?: AppNavLayout;
+  /**
+   * Render in-app links with your router's link component to keep navigation
+   * client-side (no full-page reload). Applied to the brand, nav items, primary
+   * action, and auth actions — external links always use a plain anchor.
+   */
+  linkComponent?: AppNavLinkComponent;
   user?: AppNavUser;
   authState?: AppNavAuthState;
   signInAction?: AppNavAction;
@@ -71,6 +91,7 @@ export function AppNav({
   currentServiceId,
   homeHref = '/',
   layout = 'top',
+  linkComponent,
   user,
   authState,
   signInAction,
@@ -123,10 +144,10 @@ export function AppNav({
     <>
       <header className={cx('app-nav', isSide && 'app-nav-side', className)}>
         <div className="app-nav-inner">
-          <a className="app-nav-brand" href={homeHref}>
+          <AppNavAnchor className="app-nav-brand" href={homeHref} linkComponent={linkComponent}>
             <span className="app-nav-brand-mark" aria-hidden="true" />
             <span className="app-nav-brand-name">{appName}</span>
-          </a>
+          </AppNavAnchor>
 
           <button
             type="button"
@@ -146,11 +167,13 @@ export function AppNav({
                       <div className="app-nav-section" key={group.section ?? `__ungrouped-${index}`}>
                         {group.section && <span className="app-nav-section-title">{group.section}</span>}
                         {group.items.map((item) => (
-                          <AppNavLink key={item.id} item={item} />
+                          <AppNavLink key={item.id} item={item} linkComponent={linkComponent} />
                         ))}
                       </div>
                     ))
-                  : visibleNavItems.map((item) => <AppNavLink key={item.id} item={item} />)}
+                  : visibleNavItems.map((item) => (
+                      <AppNavLink key={item.id} item={item} linkComponent={linkComponent} />
+                    ))}
               </nav>
             )}
 
@@ -158,14 +181,14 @@ export function AppNav({
               {actions}
               {primaryAction && (
                 primaryAction.href ? (
-                  <a
+                  <AppNavAnchor
                     className="btn btn-primary app-nav-primary-action"
                     href={primaryAction.href}
-                    target={primaryAction.external ? '_blank' : undefined}
-                    rel={primaryAction.external ? 'noreferrer' : undefined}
+                    external={primaryAction.external}
+                    linkComponent={linkComponent}
                   >
                     {primaryAction.label}
-                  </a>
+                  </AppNavAnchor>
                 ) : (
                   <Button className="app-nav-primary-action" onClick={primaryAction.onClick}>
                     {primaryAction.label}
@@ -192,8 +215,8 @@ export function AppNav({
               </button>
               {showAnonymousControls && (
                 <div className="app-nav-auth-actions">
-                  <AppNavActionControl action={resolvedSignInAction} className="app-nav-auth-link" />
-                  <AppNavActionControl action={resolvedSignUpAction} className="btn btn-primary app-nav-auth-primary" />
+                  <AppNavActionControl action={resolvedSignInAction} className="app-nav-auth-link" linkComponent={linkComponent} />
+                  <AppNavActionControl action={resolvedSignUpAction} className="btn btn-primary app-nav-auth-primary" linkComponent={linkComponent} />
                 </div>
               )}
               {showAuthenticatedControls && (
@@ -267,7 +290,7 @@ export function AppNav({
                 Sign out
               </Button>
             ) : (
-              <AppNavActionControl action={resolvedSignOutAction} className="btn btn-secondary app-nav-sign-out-action" />
+              <AppNavActionControl action={resolvedSignOutAction} className="btn btn-secondary app-nav-sign-out-action" linkComponent={linkComponent} />
             )}
           </div>
         </Modal>
@@ -296,18 +319,58 @@ function groupNavItems(items: readonly AppNavItem[]): AppNavGroup[] {
   return groups;
 }
 
-function AppNavLink({ item }: { item: AppNavItem }) {
+/**
+ * Renders an in-app link through `linkComponent` when one is supplied, falling
+ * back to a plain anchor. External links always use the anchor (a router link
+ * can't own a cross-origin navigation) and keep `target`/`rel`.
+ */
+function AppNavAnchor({
+  href,
+  className,
+  external,
+  ariaCurrent,
+  linkComponent: LinkComponent,
+  children
+}: {
+  href: string;
+  className?: string;
+  external?: boolean;
+  ariaCurrent?: 'page';
+  linkComponent?: AppNavLinkComponent;
+  children: ReactNode;
+}) {
+  if (LinkComponent && !external) {
+    return (
+      <LinkComponent href={href} className={className} aria-current={ariaCurrent}>
+        {children}
+      </LinkComponent>
+    );
+  }
   return (
     <a
+      className={className}
+      href={href}
+      aria-current={ariaCurrent}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+    >
+      {children}
+    </a>
+  );
+}
+
+function AppNavLink({ item, linkComponent }: { item: AppNavItem; linkComponent?: AppNavLinkComponent }) {
+  return (
+    <AppNavAnchor
       className={cx(
         'app-nav-link',
         item.active && 'app-nav-link-active',
         item.highlight && 'app-nav-link-highlight'
       )}
       href={item.href}
-      aria-current={item.active ? 'page' : undefined}
-      target={item.external ? '_blank' : undefined}
-      rel={item.external ? 'noreferrer' : undefined}
+      external={item.external}
+      ariaCurrent={item.active ? 'page' : undefined}
+      linkComponent={linkComponent}
     >
       {item.icon && (
         <span className="app-nav-link-icon" aria-hidden="true">
@@ -315,21 +378,24 @@ function AppNavLink({ item }: { item: AppNavItem }) {
         </span>
       )}
       {item.label}
-    </a>
+    </AppNavAnchor>
   );
 }
 
-function AppNavActionControl({ action, className }: { action: AppNavAction; className?: string }) {
+function AppNavActionControl({
+  action,
+  className,
+  linkComponent
+}: {
+  action: AppNavAction;
+  className?: string;
+  linkComponent?: AppNavLinkComponent;
+}) {
   if (action.href) {
     return (
-      <a
-        className={className}
-        href={action.href}
-        target={action.external ? '_blank' : undefined}
-        rel={action.external ? 'noreferrer' : undefined}
-      >
+      <AppNavAnchor className={className} href={action.href} external={action.external} linkComponent={linkComponent}>
         {action.label}
-      </a>
+      </AppNavAnchor>
     );
   }
 

--- a/ui/src/components/nav-browser.test.ts
+++ b/ui/src/components/nav-browser.test.ts
@@ -170,6 +170,58 @@ describe('mountAppNav', () => {
     expect(root.querySelector('.app-nav-avatar')?.textContent).toBe('A');
   });
 
+  it('renders the vertical side layout with grouped sections', () => {
+    handle = mountAppNav(root, {
+      appName: 'Outboxed',
+      layout: 'side',
+      navItems: [
+        { id: '/', label: 'Dashboard', href: '/', active: true },
+        { id: '/issues', label: 'Issues', href: '/issues', section: 'Publish' },
+        { id: '/subscribers', label: 'Subscribers', href: '/subscribers', section: 'Publish' },
+        { id: '/posts', label: 'Posts', href: '/posts', section: 'Content' },
+        { id: '/brand', label: 'Brand', href: '/brand' }
+      ]
+    });
+
+    expect(nav().classList.contains('app-nav-side')).toBe(true);
+
+    // Consecutive same-section items collapse into one titled group; ungrouped
+    // items keep their place as headingless runs.
+    const sections = [...root.querySelectorAll('.app-nav-section')];
+    expect(sections).toHaveLength(4);
+    const titles = sections.map((s) => s.querySelector('.app-nav-section-title')?.textContent ?? null);
+    expect(titles).toEqual([null, 'Publish', 'Content', null]);
+
+    const publishLinks = [...sections[1]!.querySelectorAll('.app-nav-link')].map((l) => l.textContent);
+    expect(publishLinks).toEqual(['Issues', 'Subscribers']);
+    expect(root.querySelector('.app-nav-link-active')?.textContent).toBe('Dashboard');
+    expect(root.querySelector('.app-nav-link-active')?.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('renders per-item icon markup and keeps the label text', () => {
+    handle = mountAppNav(root, {
+      appName: 'Outboxed',
+      layout: 'side',
+      navItems: [{ id: '/', label: 'Dashboard', href: '/', icon: '<svg data-testid="home"></svg>' }]
+    });
+    const link = root.querySelector('.app-nav-link') as HTMLElement;
+    expect(link.querySelector('.app-nav-link-icon svg[data-testid="home"]')).toBeTruthy();
+    expect(link.textContent).toBe('Dashboard');
+  });
+
+  it('does not group into sections in the default top layout', () => {
+    handle = mountAppNav(root, {
+      appName: 'RSC',
+      navItems: [
+        { id: 'a', label: 'A', href: '/a', section: 'Publish' },
+        { id: 'b', label: 'B', href: '/b', section: 'Content' }
+      ]
+    });
+    expect(nav().classList.contains('app-nav-side')).toBe(false);
+    expect(root.querySelector('.app-nav-section')).toBeNull();
+    expect([...root.querySelectorAll('.app-nav-link')].map((l) => l.textContent)).toEqual(['A', 'B']);
+  });
+
   it('destroy() removes the header and its dialogs', () => {
     handle = mountAppNav(root, { appName: 'RSC', authState: 'authenticated', user: { email: 'a@b.co' } });
     (root.querySelector('.app-nav-avatar') as HTMLButtonElement).click();

--- a/ui/src/components/nav-browser.ts
+++ b/ui/src/components/nav-browser.ts
@@ -29,6 +29,7 @@ import { getVisibleServices, readySetCloudServices, type RscService } from '../s
 
 export type AppNavTheme = 'light' | 'dark' | 'system';
 export type AppNavAuthState = 'none' | 'anonymous' | 'authenticated';
+export type AppNavLayout = 'top' | 'side';
 
 export interface AppNavUser {
   name?: string;
@@ -44,6 +45,16 @@ export interface AppNavItem {
   external?: boolean;
   highlight?: boolean;
   visible?: boolean;
+  /**
+   * Optional leading icon as an HTML/SVG markup string (e.g. '<svg>…</svg>').
+   * Inserted before the label. Trusted markup only — this is set as innerHTML.
+   */
+  icon?: string;
+  /**
+   * Optional section heading. Consecutive items sharing a section are grouped
+   * under one heading in the `side` layout (ignored in the `top` layout).
+   */
+  section?: string;
 }
 
 export interface AppNavAction {
@@ -60,6 +71,8 @@ export interface AppNavOptions {
   services?: readonly RscService[];
   currentServiceId?: string;
   homeHref?: string;
+  /** `top` (default) renders the horizontal bar; `side` renders a vertical rail. */
+  layout?: AppNavLayout;
   user?: AppNavUser;
   authState?: AppNavAuthState;
   signInAction?: AppNavAction;
@@ -160,11 +173,13 @@ export function mountAppNav(target: string | El, options: AppNavOptions): AppNav
       services = readySetCloudServices,
       currentServiceId,
       homeHref = '/',
+      layout = 'top',
       user,
       authState,
       className
     } = opts;
 
+    const isSide = layout === 'side';
     const theme = currentTheme();
     const visibleServices = getVisibleServices(services);
     const visibleNavItems = navItems.filter((item) => item.visible !== false);
@@ -178,7 +193,7 @@ export function mountAppNav(target: string | El, options: AppNavOptions): AppNav
     const initials = getInitials(user?.name ?? user?.email ?? appName);
 
     // ---- header ----
-    const header = h('header', { class: cx('app-nav', className) });
+    const header = h('header', { class: cx('app-nav', isSide && 'app-nav-side', className) });
     const inner = h('div', { class: 'app-nav-inner' });
     header.appendChild(inner);
 
@@ -207,22 +222,17 @@ export function mountAppNav(target: string | El, options: AppNavOptions): AppNav
 
     if (visibleNavItems.length > 0) {
       const nav = h('nav', { class: 'app-nav-links', 'aria-label': 'Primary navigation' });
-      for (const item of visibleNavItems) {
-        nav.appendChild(
-          h(
-            'a',
-            {
-              class: cx(
-                'app-nav-link',
-                item.active && 'app-nav-link-active',
-                item.highlight && 'app-nav-link-highlight'
-              ),
-              href: item.href,
-              ...externalAttrs(item.external)
-            },
-            item.label
-          )
-        );
+      if (isSide) {
+        for (const group of groupNavItems(visibleNavItems)) {
+          const section = h('div', { class: 'app-nav-section' });
+          if (group.section) {
+            section.appendChild(h('span', { class: 'app-nav-section-title' }, group.section));
+          }
+          for (const item of group.items) section.appendChild(navLink(item));
+          nav.appendChild(section);
+        }
+      } else {
+        for (const item of visibleNavItems) nav.appendChild(navLink(item));
       }
       collapse.appendChild(nav);
     }
@@ -445,6 +455,46 @@ export function mountAppNav(target: string | El, options: AppNavOptions): AppNav
 }
 
 /* ---------- shared helpers ---------- */
+
+interface AppNavGroup {
+  section?: string;
+  items: AppNavItem[];
+}
+
+/**
+ * Collapse a flat item list into consecutive runs sharing a `section`, keeping
+ * the caller's order so ungrouped items stay put (a standalone item at the top
+ * or bottom of a side rail is not pulled into an adjacent section).
+ */
+function groupNavItems(items: readonly AppNavItem[]): AppNavGroup[] {
+  const groups: AppNavGroup[] = [];
+  for (const item of items) {
+    const last = groups[groups.length - 1];
+    if (last && last.section === item.section) last.items.push(item);
+    else groups.push({ section: item.section, items: [item] });
+  }
+  return groups;
+}
+
+function navLink(item: AppNavItem): El {
+  const link = h('a', {
+    class: cx(
+      'app-nav-link',
+      item.active && 'app-nav-link-active',
+      item.highlight && 'app-nav-link-highlight'
+    ),
+    href: item.href,
+    ...(item.active ? { 'aria-current': 'page' } : {}),
+    ...externalAttrs(item.external)
+  });
+  if (item.icon) {
+    const iconWrap = h('span', { class: 'app-nav-link-icon', 'aria-hidden': 'true' });
+    iconWrap.innerHTML = item.icon;
+    link.appendChild(iconWrap);
+  }
+  link.appendChild(document.createTextNode(item.label));
+  return link;
+}
 
 function createDialog(className: string, label: string, onClose: () => void): HTMLDialogElement {
   const dialog = document.createElement('dialog');

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -30,6 +30,8 @@ export {
   type AppNavAuthState,
   type AppNavItem,
   type AppNavLayout,
+  type AppNavLinkComponent,
+  type AppNavLinkProps,
   type AppNavProps,
   type AppNavUser,
   type AppTheme

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -29,6 +29,7 @@ export {
   type AppNavAction,
   type AppNavAuthState,
   type AppNavItem,
+  type AppNavLayout,
   type AppNavProps,
   type AppNavUser,
   type AppTheme

--- a/ui/styles/components.css
+++ b/ui/styles/components.css
@@ -474,6 +474,7 @@
 .app-nav-link {
   display: inline-flex;
   align-items: center;
+  gap: 0.625rem;
   min-height: 2.75rem;
   padding: 0 1.25rem;
   color: rgb(var(--muted-foreground));
@@ -707,6 +708,113 @@
 
 .app-nav-sign-out-action {
   width: 100%;
+}
+
+/* Per-item icon slot (both layouts) */
+.app-nav-link-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.app-nav-link-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+.app-nav-link-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Grouped sections (rendered in the side layout; a headingless group is just
+   a run of links). */
+.app-nav-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-nav-section-title {
+  padding: 0.75rem 1.25rem 0.375rem;
+  color: rgb(var(--muted-foreground));
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* ---------- vertical (side) layout ---------- */
+/* Desktop only: below the mobile breakpoint the rail reuses the shared
+   collapsible top-bar behavior so it becomes a drawer. */
+@media (min-width: 641px) {
+  .app-nav-side {
+    width: 16rem;
+    flex: 0 0 16rem;
+    height: 100%;
+    border-bottom: 0;
+    border-right: 1px solid rgb(var(--border));
+  }
+
+  .app-nav-side .app-nav-inner {
+    min-height: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+    padding: 1.25rem 1rem;
+  }
+
+  .app-nav-side .app-nav-brand {
+    padding-inline: 0.5rem;
+  }
+
+  .app-nav-side .app-nav-collapse {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+    flex: 1 1 auto;
+  }
+
+  .app-nav-side .app-nav-links {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 1.25rem;
+    flex: 0 0 auto;
+  }
+
+  .app-nav-side .app-nav-section {
+    gap: 0.125rem;
+  }
+
+  .app-nav-side .app-nav-link {
+    min-height: 2.5rem;
+    justify-content: flex-start;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius);
+    transition: color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .app-nav-side .app-nav-link:hover {
+    background: rgb(var(--muted));
+  }
+
+  .app-nav-side .app-nav-link-active {
+    background: rgb(var(--primary-100));
+    color: rgb(var(--primary-700));
+    box-shadow: inset 3px 0 0 rgb(var(--primary-500));
+  }
+
+  .app-nav-side .app-nav-actions {
+    margin-top: auto;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Adds `layout: 'top' | 'side'` to both the React `AppNav` and the
framework-agnostic `mountAppNav`. The `side` layout renders the same nav
as a vertical 16rem rail sharing the brand mark, theme toggle, app
launcher, and profile menu.

Extends `AppNavItem` with two capabilities the side layout uses:
- `icon` — a leading icon (React node; HTML/SVG string for the vanilla build)
- `section` — a heading; consecutive same-section items are grouped, while
  ungrouped items keep their place (standalone top/bottom rail items)

Active/hover/highlight are themed from shared tokens in light and dark, and
the rail collapses to the existing hamburger drawer below the mobile
breakpoint. Documented in README + AGENTS with an example, exported
`AppNavLayout`, and bumped the package to 0.3.0.

Implements readysetcloud/newsletter-service#327.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S6UqAFF9ZrZK59zSKNWydc