### PR TITLE
feat: add cross-app badge chest (gamification) architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,66 @@ The configured deployment parameters above will be accessible by using the follo
 * Cognito User Pool ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-id}}`
 * Cognito User Pool ARN - `{{resolve:ssm:/readysetcloud/auth/user-pool-arn}}`
 * Cognito User Pool Client ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-client-id}}`
+* Badge Chest API URL - `{{resolve:ssm:/readysetcloud/badges/api-url}}`
+
+## Badge Chest — cross-app gamification
+
+The badge chest is a single, ecosystem-wide trophy case. Because every app
+shares one Cognito user pool, a user's Cognito `sub` is a universal identity, so
+badges, points, and levels earned in any app roll up into one profile stored in
+`RSCCoreTable`.
+
+### How it works
+
+1. **Apps emit activity.** An app tells core that something happened — either by
+   putting a `Track Activity` event on the default EventBridge bus, or by having
+   a signed-in user `POST /badges/activity`.
+2. **The rules engine awards badges.** `ProcessActivityFunction` counts the
+   activity, checks the central catalog (`functions/badges/catalog.json`), and
+   idempotently awards any newly-earned badges, adding their points to the
+   user's total and recomputing their level (`functions/badges/levels.json`).
+3. **Core announces it.** A `Badge Awarded` (and, on a level change, `Level Up`)
+   event goes back on the bus for any app to react to (toast, email, etc.).
+4. **Apps read the chest.** The shared `<BadgeChest>` component in
+   `@readysetcloud/ui` calls `GET /badges/me` to render the user's badges,
+   points, level, and progress identically everywhere.
+
+### Activity event contract
+
+Emit this to the default bus (or POST the `detail` body, minus `userId`, to
+`/badges/activity` where `userId` is taken from the JWT):
+
+```json
+{
+  "Source": "<your-app>",
+  "DetailType": "Track Activity",
+  "Detail": {
+    "id": "<uuid>",            // optional idempotency key — reuse on retries
+    "userId": "<cognito sub>", // required for bus events; set from JWT by the API
+    "action": "lesson.completed",
+    "count": 1,                 // optional, default 1
+    "value": "bootcamp",       // optional — distinct value for `unique` badges
+    "service": "bootcamp"      // optional — enables per-service badge criteria
+  }
+}
+```
+
+### Adding a badge
+
+Add an entry to `functions/badges/catalog.json` and redeploy. Supported
+criteria types:
+
+* `count` — award at `threshold` occurrences of `metric` (add `service` to
+  scope the count to one app).
+* `unique` — award when `threshold` distinct `value`s are seen for `metric`
+  (e.g. "visited every app").
+* `meta` — award when `threshold` of the listed `badges` are earned (e.g.
+  "collect them all").
+
+### API
+
+| Method & path | Auth | Purpose |
+| --- | --- | --- |
+| `GET /badges/me` | Cognito JWT | The caller's chest: badges, points, level, in-progress |
+| `GET /badges/catalog` | none | Every earnable badge + the level ladder |
+| `POST /badges/activity` | Cognito JWT | Record activity for the caller |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The configured deployment parameters above will be accessible by using the follo
 * Cognito User Pool ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-id}}`
 * Cognito User Pool ARN - `{{resolve:ssm:/readysetcloud/auth/user-pool-arn}}`
 * Cognito User Pool Client ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-client-id}}`
-* Badge Chest API URL - `{{resolve:ssm:/readysetcloud/badges/api-url}}`
+* Core API URL - `{{resolve:ssm:/readysetcloud/api-url}}` (prod: `https://api.readysetcloud.io`)
 
 ## Badge Chest — cross-app gamification
 
@@ -101,6 +101,13 @@ criteria types:
   "collect them all").
 
 ### API
+
+Badge routes are served by the shared **Core API** (`AWS::Serverless::HttpApi`
+`CoreApi`). Its base URL is published to SSM at `/readysetcloud/api-url`. In prod
+(any deploy with `RootDomainName` set) it is fronted by a custom domain,
+`api.${RootDomainName}` — e.g. `https://api.readysetcloud.io`; non-prod deploys
+fall back to the generated `execute-api` URL. This is the ecosystem's core API
+surface — badges are its first routes, more will live here over time.
 
 | Method & path | Auth | Purpose |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ shares one Cognito user pool, a user's Cognito `sub` is a universal identity, so
 badges, points, and levels earned in any app roll up into one profile stored in
 `RSCCoreTable`.
 
+> **Full integration & authoring guide:** [`functions/badges/AGENTS.md`](functions/badges/AGENTS.md)
+> — how to emit activity from an app, how to author a badge (criteria types,
+> counter scoping, gotchas), the events the engine emits, and the data model.
+> The section below is the overview.
+
 ### How it works
 
 1. **Apps emit activity.** An app tells core that something happened — either by
@@ -99,6 +104,11 @@ criteria types:
   (e.g. "visited every app").
 * `meta` — award when `threshold` of the listed `badges` are earned (e.g.
   "collect them all").
+
+Adding a badge does **not** retroactively scan history — a user earns it on
+their next matching activity, so plan a replay/backfill for badges added after
+launch. See the [authoring guide](functions/badges/AGENTS.md#authoring-a-badge)
+for criteria/counter details and the events the engine emits.
 
 ### API
 

--- a/functions/add-tenant-post-confirmation.mjs
+++ b/functions/add-tenant-post-confirmation.mjs
@@ -1,20 +1,36 @@
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 
 const ddb = new DynamoDBClient();
+const eventBridge = new EventBridgeClient();
 
 export const handler = async (event) => {
+  const userId = event.request.userAttributes.sub;
   try {
     await ddb.send(new PutItemCommand({
       TableName: process.env.TABLE_NAME,
       Item: marshall({
-        pk: event.request.userAttributes.sub,
+        pk: userId,
         sk: 'tenant',
         signUpDate: new Date().toISOString(),
         ...event.userName && { username: event.userName }
       })
     }));
+
+    // Kick off the gamification loop — earns the "Welcome Aboard" badge.
+    await eventBridge.send(new PutEventsCommand({
+      Entries: [
+        {
+          Source: 'rsc-core',
+          DetailType: 'Track Activity',
+          Detail: JSON.stringify({ id: `account-created#${userId}`, userId, action: 'account.created' })
+        }
+      ]
+    }));
   } catch (err) {
     console.log(err);
   }
+
+  return event;
 };

--- a/functions/badges/AGENTS.md
+++ b/functions/badges/AGENTS.md
@@ -1,0 +1,248 @@
+# Badge Chest — integration & authoring guide
+
+Agent/developer guide for the cross-app gamification system in `rsc-core`. Read
+this before adding a badge, wiring an app to emit activity, or debugging why a
+badge did/didn't award.
+
+- **Consuming from another app?** Start at [Emitting activity](#emitting-activity-for-app-authors).
+- **Adding or changing a badge?** Start at [Authoring a badge](#authoring-a-badge).
+- **Reading the chest / rendering UI?** See [Reading the chest](#reading-the-chest)
+  and the `BadgeChest` section of `ui/AGENTS.md`.
+
+## Mental model
+
+There is **one badge chest per person**, keyed on their Cognito `sub` — which is
+the same identity in every RSC app. So badges, points, and levels earned
+anywhere roll up into a single profile in the shared `RSCCoreTable`.
+
+```
+your app ──"Track Activity"──▶ process-activity ──▶ counters + awards + points/level
+   │           (EventBridge bus                          │
+   │            or POST /badges/activity)                 ├──▶ "Badge Awarded"
+   │                                                      └──▶ "Level Up"
+   └──GET /badges/me──▶ renders <BadgeChest>          (back on the bus for anyone)
+```
+
+Apps only ever do two things: **emit activity** ("this happened") and
+**read the chest** ("show me my badges"). They never decide what a badge is
+worth or whether it's earned — the central rules engine owns that.
+
+The moving parts, all in this repo:
+
+| Piece | File | Role |
+| --- | --- | --- |
+| Catalog | `functions/badges/catalog.json` | The badge definitions (source of truth) |
+| Levels | `functions/badges/levels.json` | Point thresholds → levels |
+| Rules (pure) | `functions/utils/badges.mjs` | Indexing, criteria eval, level calc |
+| Rules engine | `functions/process-activity.mjs` | Consumes activity, awards, rolls up points |
+| Ingress | `functions/record-activity.mjs` | `POST /badges/activity` for clients |
+| Read API | `functions/get-badge-chest.mjs`, `get-badge-catalog.mjs` | `GET /badges/me`, `/badges/catalog` |
+| UI | `@readysetcloud/ui` → `BadgeChest`, `createBadgeClient` | Render + fetch |
+
+## Emitting activity (for app authors)
+
+An **activity** is a fact: "user X did Y." You emit it; the engine decides
+whether it earns anything. Same payload whichever transport you use.
+
+### The activity contract
+
+```json
+{
+  "id": "8f3c…",            // optional idempotency key (see below)
+  "userId": "<cognito sub>", // REQUIRED on the bus; the API sets it from the JWT
+  "action": "lesson.completed",
+  "count": 1,                // optional, default 1
+  "value": "bootcamp",       // optional — the distinct value for `unique` badges
+  "service": "bootcamp"      // optional — required for service-scoped badges
+}
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `action` | yes | The metric name. This is the contract — keep it **stable**. Convention: lowercase, dot-namespaced `noun.verb` (`lesson.completed`, `campaign.created`). |
+| `userId` | on the bus | The Cognito `sub`. The `POST /badges/activity` endpoint ignores any `userId` in the body and uses the caller's JWT. |
+| `id` | recommended | Idempotency key. If set, the engine processes this activity **exactly once** (safe under EventBridge's at-least-once delivery and client retries). Omit only for activity where an occasional double-count is harmless. |
+| `count` | no | Increment size (default 1). Use for "read 5 articles at once" style batches. |
+| `value` | no | The distinct dimension for `unique` badges (e.g. the service id for "visited every app"). Defaults to `service` if omitted. |
+| `service` | no | The emitting app. **Required** if any badge scopes its count to a service (see the gotcha below). |
+
+### Two ways to emit
+
+**Backend (EventBridge, preferred for server-side events):**
+
+```js
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+const eb = new EventBridgeClient();
+
+await eb.send(new PutEventsCommand({
+  Entries: [{
+    Source: 'bootcamp',            // your app — any value; the engine matches on DetailType
+    DetailType: 'Track Activity',
+    Detail: JSON.stringify({
+      id: `lesson#${userId}#${lessonId}`,
+      userId,
+      action: 'lesson.completed',
+      service: 'bootcamp'
+    })
+  }]
+}));
+```
+
+**Client (via the Core API, when there's no backend for the event):**
+
+```ts
+import { createBadgeClient } from '@readysetcloud/ui';
+const badges = createBadgeClient({ baseUrl: CORE_API_URL, getToken });
+
+await badges.recordActivity({ action: 'lesson.completed', service: 'bootcamp' });
+```
+
+`recordActivity` just re-emits a `Track Activity` event with `userId` taken from
+the verified token, so both paths land in the same rules engine.
+
+### Picking a good idempotency `id`
+
+Make it deterministic from the thing that happened, so a retry produces the same
+id: `lesson#<userId>#<lessonId>`, `subscribe#<userId>`, `visit#<userId>#<service>#<yyyymmdd>`.
+The engine writes a short-lived dedupe marker per id; a second delivery of the
+same id is dropped before any counter moves.
+
+## Authoring a badge
+
+Add an entry to `functions/badges/catalog.json` and deploy. No code changes are
+needed for the three built-in criteria types.
+
+```json
+{
+  "id": "lesson-streak",
+  "name": "Scholar",
+  "description": "Completed 10 bootcamp lessons.",
+  "icon": "🎓",
+  "category": "Learning",
+  "tier": "silver",
+  "points": 75,
+  "service": "bootcamp",
+  "criteria": { "type": "count", "metric": "lesson.completed", "threshold": 10, "service": "bootcamp" }
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `id` | Stable, unique, kebab-case. Used as the DynamoDB key — **never reuse or rename** an id that has been awarded. |
+| `name`, `description` | Human copy shown in the chest. |
+| `icon` | Emoji today; an `iconUrl` art field is on the roadmap (UI already prefers art when present). |
+| `category` | Grouping label (e.g. `Learning`, `Ecosystem`). |
+| `tier` | `bronze` \| `silver` \| `gold` \| `platinum` — drives the tile accent. |
+| `points` | Added to the user's total when earned; feeds levels (`levels.json`). |
+| `service` | Optional label for which app the badge belongs to (display + filtering). Distinct from `criteria.service`, which actually scopes the count. |
+| `criteria` | How it's earned — see below. |
+
+### Criteria types
+
+| Type | Shape | Earned when | Reads counter |
+| --- | --- | --- | --- |
+| `count` | `{ type, metric, threshold, service? }` | `metric` has occurred `threshold`+ times | `progress#<metric>`, or `progress#<service>#<metric>` if `service` set |
+| `unique` | `{ type, metric, threshold }` | `threshold`+ **distinct** `value`s seen for `metric` | `unique#<metric>` (a DynamoDB string set) |
+| `meta` | `{ type, badges: [...], threshold? }` | `threshold` of the listed badges are earned (default: all) | none — reads the user's earned set |
+
+Examples:
+
+```jsonc
+// First time only:
+{ "type": "count", "metric": "account.created", "threshold": 1 }
+
+// Used every app in the ecosystem (emit value = service id):
+{ "type": "unique", "metric": "service.visited", "threshold": 5 }
+
+// Collect a badge in four corners of the ecosystem:
+{ "type": "meta", "badges": ["newsletter-subscriber", "first-lesson", "first-campaign", "green-thumb"], "threshold": 4 }
+```
+
+### How activity maps to counters (why scoping matters)
+
+Each activity increments an **ecosystem-wide** counter (`progress#<metric>`),
+and — only when the activity carries a `service` **and** some badge scopes that
+metric — a **per-service** counter (`progress#<service>#<metric>`). A `unique`
+metric instead adds `value` to a distinct set (`unique#<metric>`).
+
+**Gotcha:** a badge with `criteria.service` is only satisfied by the
+`progress#<service>#<metric>` counter, which only moves when the emitted
+activity includes a matching `service`. If you author a service-scoped badge,
+the app **must** emit `service` on that activity, and it must equal
+`criteria.service`. Ecosystem badges (no `criteria.service`) count every
+occurrence regardless of `service`.
+
+**Gotcha:** a `unique` badge needs a `value` (or a `service`, which is used as
+the fallback) on each activity — with neither, there's nothing to add to the
+distinct set and the counter never grows.
+
+### Authoring checklist
+
+1. Add the entry to `catalog.json` with a stable `id`.
+2. Make sure **something emits** the `metric` you reference (an app, or the
+   signup hook). A badge whose metric is never emitted can never be earned.
+3. If service-scoped, confirm the emitter sends a matching `service`.
+4. Bump `version` in `catalog.json` if you want consumers to detect the change.
+5. Deploy. `GET /badges/catalog` now advertises it.
+
+**Gotcha — no automatic backfill:** adding a badge does **not** retroactively
+scan history. A user who already passed the threshold gets it on their **next**
+matching activity (which re-triggers evaluation); if they never do that activity
+again, they won't earn it. To grant badges for things that happened before the
+badge existed, replay historical activity through the engine or run a one-time
+grant. Plan this for any badge added after launch.
+
+## What the engine guarantees
+
+- **Award once.** Badges are written with a conditional put; retries and
+  concurrent events can't double-award or double-count points.
+- **Exactly-once counting** for activity that carries an `id` (dedupe marker
+  with TTL). Without an `id`, counting is at-least-once.
+- **Points & levels roll up automatically** on every award; a level change emits
+  `Level Up`.
+- **Meta badges are re-checked** whenever any badge is newly awarded in the same
+  event, so "collect them all" fires as soon as the last dependency lands.
+- **Cheap no-ops.** Activity whose `action` no badge references is ignored
+  immediately.
+
+## Events the engine emits
+
+React to these on the default bus (e.g. to toast or email the user):
+
+```jsonc
+// DetailType: "Badge Awarded"  (one per badge earned)
+{ "userId", "badge": { "id", "name", "description", "icon", "category", "tier", "points", "service?" },
+  "totalPoints", "level", "levelName", "earnedDate" }
+
+// DetailType: "Level Up"  (only when the level changed)
+{ "userId", "level", "levelName", "totalPoints" }
+```
+
+## Reading the chest
+
+| Method & path | Auth | Purpose |
+| --- | --- | --- |
+| `GET /badges/me` | Cognito JWT | Caller's chest: badges, points, level, in-progress |
+| `GET /badges/catalog` | none | Every earnable badge + the level ladder |
+| `POST /badges/activity` | Cognito JWT | Record activity for the caller |
+
+Base URL is in SSM at `/readysetcloud/api-url` (prod: `https://api.readysetcloud.io`).
+Use `createBadgeClient` + `<BadgeChest>` from `@readysetcloud/ui` so every app
+renders identically — see `ui/AGENTS.md`.
+
+## Data model (for debugging)
+
+All items are keyed `pk = <cognito sub>`:
+
+| `sk` | Contents |
+| --- | --- |
+| `gamification` | `{ totalPoints, badgeCount, level, levelName, updatedDate }` |
+| `badge#<id>` | `{ badgeId, points, earnedDate, service? }` — an earned badge |
+| `progress#<metric>` | `{ count }` — ecosystem counter |
+| `progress#<service>#<metric>` | `{ count }` — per-service counter |
+| `unique#<metric>` | `{ values }` — distinct-value string set |
+| `evt#<id>` | dedupe marker with `ttl` (auto-expires) |
+
+The pure logic (criteria eval, counter keys, level math) lives in
+`functions/utils/badges.mjs` and has no AWS dependencies — reason about or unit
+test awarding there without deploying.

--- a/functions/badges/catalog.json
+++ b/functions/badges/catalog.json
@@ -1,0 +1,94 @@
+{
+  "version": 1,
+  "badges": [
+    {
+      "id": "welcome",
+      "name": "Welcome Aboard",
+      "description": "Created your Ready, Set, Cloud account.",
+      "icon": "🎉",
+      "category": "Milestones",
+      "tier": "bronze",
+      "points": 10,
+      "criteria": { "type": "count", "metric": "account.created", "threshold": 1 }
+    },
+    {
+      "id": "explorer",
+      "name": "Ecosystem Explorer",
+      "description": "Visited every app in the Ready, Set, Cloud ecosystem.",
+      "icon": "🧭",
+      "category": "Ecosystem",
+      "tier": "gold",
+      "points": 100,
+      "criteria": { "type": "unique", "metric": "service.visited", "threshold": 5 }
+    },
+    {
+      "id": "newsletter-subscriber",
+      "name": "In the Loop",
+      "description": "Subscribed to the Picks of the Week newsletter.",
+      "icon": "📰",
+      "category": "Newsletter",
+      "tier": "bronze",
+      "points": 15,
+      "service": "outboxed",
+      "criteria": { "type": "count", "metric": "newsletter.subscribed", "threshold": 1 }
+    },
+    {
+      "id": "first-lesson",
+      "name": "Getting Started",
+      "description": "Completed your first bootcamp lesson.",
+      "icon": "📗",
+      "category": "Learning",
+      "tier": "bronze",
+      "points": 20,
+      "service": "bootcamp",
+      "criteria": { "type": "count", "metric": "lesson.completed", "threshold": 1, "service": "bootcamp" }
+    },
+    {
+      "id": "lesson-streak",
+      "name": "Scholar",
+      "description": "Completed 10 bootcamp lessons.",
+      "icon": "🎓",
+      "category": "Learning",
+      "tier": "silver",
+      "points": 75,
+      "service": "bootcamp",
+      "criteria": { "type": "count", "metric": "lesson.completed", "threshold": 10, "service": "bootcamp" }
+    },
+    {
+      "id": "first-campaign",
+      "name": "Deal Maker",
+      "description": "Tracked your first paid campaign in Booked.",
+      "icon": "🤝",
+      "category": "Creators",
+      "tier": "bronze",
+      "points": 20,
+      "service": "booked",
+      "criteria": { "type": "count", "metric": "campaign.created", "threshold": 1, "service": "booked" }
+    },
+    {
+      "id": "green-thumb",
+      "name": "Green Thumb",
+      "description": "Completed a lesson at Olivia's Garden Foundation.",
+      "icon": "🌱",
+      "category": "Nonprofit",
+      "tier": "bronze",
+      "points": 20,
+      "service": "olivias-garden-foundation",
+      "criteria": { "type": "count", "metric": "garden.lesson.completed", "threshold": 1, "service": "olivias-garden-foundation" }
+    },
+    {
+      "id": "completionist",
+      "name": "Completionist",
+      "description": "Earned a badge in four different corners of the ecosystem.",
+      "icon": "🏆",
+      "category": "Ecosystem",
+      "tier": "platinum",
+      "points": 150,
+      "criteria": {
+        "type": "meta",
+        "badges": ["newsletter-subscriber", "first-lesson", "first-campaign", "green-thumb"],
+        "threshold": 4
+      }
+    }
+  ]
+}

--- a/functions/badges/levels.json
+++ b/functions/badges/levels.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "levels": [
+    { "level": 1, "name": "Cloud Curious", "minPoints": 0 },
+    { "level": 2, "name": "Cloud Explorer", "minPoints": 50 },
+    { "level": 3, "name": "Cloud Builder", "minPoints": 150 },
+    { "level": 4, "name": "Cloud Architect", "minPoints": 350 },
+    { "level": 5, "name": "Cloud Sage", "minPoints": 700 }
+  ]
+}

--- a/functions/get-badge-catalog.mjs
+++ b/functions/get-badge-catalog.mjs
@@ -1,0 +1,20 @@
+import { BADGES, LEVELS, CATALOG_VERSION, toPublicBadge } from './utils/badges.mjs';
+
+/**
+ * Public catalog of every badge that can be earned plus the level ladder. Apps
+ * use this to render "here's what you can unlock" and to look up badge metadata
+ * for badges a user hasn't earned yet. No auth required — it's static reference
+ * data with no user context.
+ */
+export const handler = async () => ({
+  statusCode: 200,
+  headers: {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=300'
+  },
+  body: JSON.stringify({
+    version: CATALOG_VERSION,
+    badges: BADGES.map(toPublicBadge),
+    levels: LEVELS
+  })
+});

--- a/functions/get-badge-chest.mjs
+++ b/functions/get-badge-chest.mjs
@@ -1,0 +1,122 @@
+import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+  BADGES,
+  getBadge,
+  toPublicBadge,
+  computeLevel,
+  getNextLevel
+} from './utils/badges.mjs';
+
+const ddb = new DynamoDBClient();
+const TABLE_NAME = process.env.TABLE_NAME;
+
+/**
+ * Returns the signed-in user's badge chest: earned badges (joined to the
+ * catalog), their point total and level, and progress toward the badges they
+ * haven't unlocked yet. This is the single read the shared BadgeChest UI hits.
+ */
+export const handler = async (event) => {
+  const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+  if (!userId) {
+    return response(401, { message: 'Unauthorized' });
+  }
+
+  const items = await queryUser(userId);
+
+  let summary;
+  const earned = [];
+  const counters = {};
+  for (const item of items) {
+    if (item.sk === 'gamification') summary = item;
+    else if (item.sk.startsWith('badge#')) earned.push(item);
+    else if (item.sk.startsWith('progress#')) counters[item.sk] = Number(item.count ?? 0);
+    else if (item.sk.startsWith('unique#')) {
+      counters[item.sk] = item.values instanceof Set ? item.values.size : 0;
+    }
+  }
+
+  const earnedIds = new Set(earned.map((e) => e.badgeId));
+  const totalPoints = Number(summary?.totalPoints ?? 0);
+  const level = computeLevel(totalPoints);
+  const nextLevel = getNextLevel(totalPoints);
+
+  const badges = earned
+    .map((e) => {
+      const def = getBadge(e.badgeId);
+      return {
+        ...(def ? toPublicBadge(def) : { id: e.badgeId, points: e.points }),
+        earnedDate: e.earnedDate
+      };
+    })
+    .sort((a, b) => (a.earnedDate < b.earnedDate ? 1 : -1));
+
+  const inProgress = BADGES
+    .filter((b) => !earnedIds.has(b.id))
+    .map((b) => ({
+      ...toPublicBadge(b),
+      current: currentProgress(b, counters, earnedIds),
+      threshold: threshold(b)
+    }))
+    .filter((b) => b.threshold > 0);
+
+  return response(200, {
+    points: totalPoints,
+    level: level.level,
+    levelName: level.name,
+    levelMinPoints: level.minPoints,
+    nextLevel: nextLevel && {
+      level: nextLevel.level,
+      name: nextLevel.name,
+      minPoints: nextLevel.minPoints,
+      pointsToGo: nextLevel.pointsToGo
+    },
+    badgeCount: badges.length,
+    badges,
+    inProgress
+  });
+};
+
+const threshold = (badge) => {
+  const c = badge.criteria;
+  if (c.type === 'meta') return c.threshold ?? c.badges.length;
+  return c.threshold ?? 1;
+};
+
+const currentProgress = (badge, counters, earnedIds) => {
+  const c = badge.criteria;
+  switch (c.type) {
+    case 'count': {
+      const key = c.service ? `progress#${c.service}#${c.metric}` : `progress#${c.metric}`;
+      return Math.min(counters[key] ?? 0, c.threshold);
+    }
+    case 'unique':
+      return Math.min(counters[`unique#${c.metric}`] ?? 0, c.threshold);
+    case 'meta':
+      return c.badges.filter((id) => earnedIds.has(id)).length;
+    default:
+      return 0;
+  }
+};
+
+const queryUser = async (userId) => {
+  const items = [];
+  let ExclusiveStartKey;
+  do {
+    const res = await ddb.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: marshall({ ':pk': userId }),
+      ExclusiveStartKey
+    }));
+    for (const item of res.Items ?? []) items.push(unmarshall(item));
+    ExclusiveStartKey = res.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+  return items;
+};
+
+const response = (statusCode, body) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body)
+});

--- a/functions/process-activity.mjs
+++ b/functions/process-activity.mjs
@@ -1,0 +1,241 @@
+import {
+  DynamoDBClient,
+  UpdateItemCommand,
+  PutItemCommand,
+  QueryCommand
+} from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  getBadgesForMetric,
+  getCountersForActivity,
+  counterKey,
+  isEarned,
+  computeLevel,
+  toPublicBadge,
+  META_BADGES,
+  getBadge
+} from './utils/badges.mjs';
+
+const ddb = new DynamoDBClient();
+const eventBridge = new EventBridgeClient();
+const TABLE_NAME = process.env.TABLE_NAME;
+
+// Dedupe markers auto-expire; long enough to absorb any realistic retry/replay window.
+const DEDUPE_TTL_DAYS = 90;
+
+/**
+ * The gamification rules engine. Consumes a single "Track Activity" event from
+ * EventBridge, increments the relevant progress counters, evaluates the badges
+ * that activity can affect, awards any newly-earned ones (idempotently), rolls
+ * the points up into the user's level, and emits "Badge Awarded" / "Level Up"
+ * events for the rest of the ecosystem to react to.
+ */
+export const handler = async (event) => {
+  const detail = event.detail ?? event;
+  const { id, userId, action, service } = detail;
+  const amount = Number(detail.count ?? 1);
+  const value = detail.value ?? service;
+
+  if (!userId || !action) {
+    console.warn('Skipping activity with missing userId/action', JSON.stringify(detail));
+    return;
+  }
+
+  // Nothing in the catalog cares about this activity — cheap early exit.
+  if (!getBadgesForMetric(action).length) return;
+
+  // Idempotency: a repeated delivery of the same activity id must not double count.
+  if (id && !(await claimActivity(userId, id))) return;
+
+  const counters = await incrementCounters(userId, action, service, amount, value);
+  const earnedIds = await getEarnedBadgeIds(userId);
+
+  const newlyAwarded = [];
+
+  for (const badge of getBadgesForMetric(action)) {
+    if (earnedIds.has(badge.id)) continue;
+    if (!isEarned(badge, counters, earnedIds)) continue;
+    if (await awardBadge(userId, badge)) {
+      earnedIds.add(badge.id);
+      newlyAwarded.push(badge);
+    }
+  }
+
+  // Meta badges ("collect them all") react to other badges being earned.
+  if (newlyAwarded.length) {
+    for (const meta of META_BADGES) {
+      if (earnedIds.has(meta.id)) continue;
+      if (!isEarned(meta, counters, earnedIds)) continue;
+      if (await awardBadge(userId, meta)) {
+        earnedIds.add(meta.id);
+        newlyAwarded.push(meta);
+      }
+    }
+  }
+
+  if (!newlyAwarded.length) return;
+
+  const { totalPoints, level, leveledUp } = await applyPoints(userId, newlyAwarded);
+  await publishAwards(userId, newlyAwarded, totalPoints, level, leveledUp);
+};
+
+/** Writes a dedupe marker; returns false if this activity id was already processed. */
+const claimActivity = async (userId, id) => {
+  const ttl = Math.floor(Date.now() / 1000) + DEDUPE_TTL_DAYS * 24 * 60 * 60;
+  try {
+    await ddb.send(new PutItemCommand({
+      TableName: TABLE_NAME,
+      Item: marshall({ pk: userId, sk: `evt#${id}`, ttl }),
+      ConditionExpression: 'attribute_not_exists(pk)'
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+};
+
+/**
+ * Increments every counter this activity feeds and returns a map of
+ * counterKey -> current value for the counters that were actually touched.
+ */
+const incrementCounters = async (userId, action, service, amount, value) => {
+  const counters = getCountersForActivity(action, service);
+  const result = {};
+
+  await Promise.all(counters.map(async (counter) => {
+    const sk = counterKey(counter);
+
+    if (counter.unique) {
+      if (!value) return; // nothing to add to the distinct set
+      const res = await ddb.send(new UpdateItemCommand({
+        TableName: TABLE_NAME,
+        Key: marshall({ pk: userId, sk }),
+        UpdateExpression: 'ADD #values :val SET #updated = :now',
+        ExpressionAttributeNames: { '#values': 'values', '#updated': 'updatedDate' },
+        ExpressionAttributeValues: marshall(
+          { ':val': new Set([String(value)]), ':now': new Date().toISOString() }
+        ),
+        ReturnValues: 'UPDATED_NEW'
+      }));
+      const values = unmarshall(res.Attributes).values;
+      result[sk] = values instanceof Set ? values.size : new Set(values).size;
+    } else {
+      const res = await ddb.send(new UpdateItemCommand({
+        TableName: TABLE_NAME,
+        Key: marshall({ pk: userId, sk }),
+        UpdateExpression: 'ADD #count :amt SET #updated = :now',
+        ExpressionAttributeNames: { '#count': 'count', '#updated': 'updatedDate' },
+        ExpressionAttributeValues: marshall({ ':amt': amount, ':now': new Date().toISOString() }),
+        ReturnValues: 'UPDATED_NEW'
+      }));
+      result[sk] = Number(unmarshall(res.Attributes).count);
+    }
+  }));
+
+  return result;
+};
+
+/** Returns the set of badge ids the user has already earned. */
+const getEarnedBadgeIds = async (userId) => {
+  const ids = new Set();
+  let ExclusiveStartKey;
+  do {
+    const res = await ddb.send(new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk AND begins_with(sk, :prefix)',
+      ExpressionAttributeValues: marshall({ ':pk': userId, ':prefix': 'badge#' }),
+      ProjectionExpression: 'sk',
+      ExclusiveStartKey
+    }));
+    for (const item of res.Items ?? []) {
+      ids.add(unmarshall(item).sk.replace('badge#', ''));
+    }
+    ExclusiveStartKey = res.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+  return ids;
+};
+
+/** Idempotently records an earned badge. Returns false if it was already earned. */
+const awardBadge = async (userId, badge) => {
+  try {
+    await ddb.send(new PutItemCommand({
+      TableName: TABLE_NAME,
+      Item: marshall({
+        pk: userId,
+        sk: `badge#${badge.id}`,
+        badgeId: badge.id,
+        points: badge.points,
+        earnedDate: new Date().toISOString(),
+        ...(badge.service && { service: badge.service })
+      }),
+      ConditionExpression: 'attribute_not_exists(pk)'
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+};
+
+/** Adds the awarded points to the user's summary and recomputes their level. */
+const applyPoints = async (userId, badges) => {
+  const added = badges.reduce((sum, b) => sum + (b.points ?? 0), 0);
+
+  const res = await ddb.send(new UpdateItemCommand({
+    TableName: TABLE_NAME,
+    Key: marshall({ pk: userId, sk: 'gamification' }),
+    UpdateExpression: 'ADD totalPoints :pts, badgeCount :cnt SET updatedDate = :now',
+    ExpressionAttributeValues: marshall({
+      ':pts': added,
+      ':cnt': badges.length,
+      ':now': new Date().toISOString()
+    }),
+    ReturnValues: 'UPDATED_NEW'
+  }));
+
+  const totalPoints = Number(unmarshall(res.Attributes).totalPoints);
+  const newLevel = computeLevel(totalPoints);
+  const oldLevel = computeLevel(totalPoints - added);
+  const leveledUp = newLevel.level !== oldLevel.level;
+
+  await ddb.send(new UpdateItemCommand({
+    TableName: TABLE_NAME,
+    Key: marshall({ pk: userId, sk: 'gamification' }),
+    UpdateExpression: 'SET #level = :level, levelName = :name',
+    ExpressionAttributeNames: { '#level': 'level' },
+    ExpressionAttributeValues: marshall({ ':level': newLevel.level, ':name': newLevel.name })
+  }));
+
+  return { totalPoints, level: newLevel, leveledUp };
+};
+
+/** Emits "Badge Awarded" (one per badge) and an optional "Level Up" event. */
+const publishAwards = async (userId, badges, totalPoints, level, leveledUp) => {
+  const entries = badges.map((badge) => ({
+    Source: 'rsc-core',
+    DetailType: 'Badge Awarded',
+    Detail: JSON.stringify({
+      userId,
+      badge: toPublicBadge(getBadge(badge.id)),
+      totalPoints,
+      level: level.level,
+      levelName: level.name,
+      earnedDate: new Date().toISOString()
+    })
+  }));
+
+  if (leveledUp) {
+    entries.push({
+      Source: 'rsc-core',
+      DetailType: 'Level Up',
+      Detail: JSON.stringify({ userId, level: level.level, levelName: level.name, totalPoints })
+    });
+  }
+
+  // PutEvents accepts at most 10 entries per call.
+  for (let i = 0; i < entries.length; i += 10) {
+    await eventBridge.send(new PutEventsCommand({ Entries: entries.slice(i, i + 10) }));
+  }
+};

--- a/functions/record-activity.mjs
+++ b/functions/record-activity.mjs
@@ -1,0 +1,58 @@
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { randomUUID } from 'crypto';
+
+const eventBridge = new EventBridgeClient();
+
+/**
+ * Authenticated ingress for gamification activity. Lets client-side apps record
+ * activity ("I completed a lesson", "I visited this app") without needing their
+ * own EventBridge access. The user is taken from the verified JWT — never the
+ * body — then the activity is emitted as a "Track Activity" event that the
+ * rules engine (process-activity) consumes.
+ */
+export const handler = async (event) => {
+  const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+  if (!userId) {
+    return response(401, { message: 'Unauthorized' });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body ?? '{}');
+  } catch {
+    return response(400, { message: 'Invalid JSON body' });
+  }
+
+  const { action, count, value, service } = body;
+  if (!action || typeof action !== 'string') {
+    return response(400, { message: 'action is required' });
+  }
+
+  // Client-supplied id enables exactly-once counting across retries.
+  const id = body.id ?? randomUUID();
+
+  await eventBridge.send(new PutEventsCommand({
+    Entries: [
+      {
+        Source: 'rsc-core',
+        DetailType: 'Track Activity',
+        Detail: JSON.stringify({
+          id,
+          userId,
+          action,
+          ...(count != null && { count }),
+          ...(value != null && { value }),
+          ...(service && { service })
+        })
+      }
+    ]
+  }));
+
+  return response(202, { id });
+};
+
+const response = (statusCode, body) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body)
+});

--- a/functions/utils/badges.mjs
+++ b/functions/utils/badges.mjs
@@ -1,0 +1,125 @@
+import catalog from '../badges/catalog.json';
+import levels from '../badges/levels.json';
+
+/**
+ * Shared badge/gamification logic for the RSC "badge chest".
+ *
+ * This module owns the pure rules: the badge catalog, how a raw activity
+ * metric maps to the badges that care about it, whether a badge's criteria are
+ * met given the user's current counters, and how total points roll up into a
+ * level. It has no AWS dependencies so it can be unit tested and reused by any
+ * function that needs to reason about badges.
+ */
+
+export const CATALOG_VERSION = catalog.version;
+export const BADGES = catalog.badges;
+export const LEVELS = [...levels.levels].sort((a, b) => a.minPoints - b.minPoints);
+
+const BADGES_BY_ID = new Map(BADGES.map((b) => [b.id, b]));
+
+// metric -> badges whose criteria are driven by that metric. Built once so the
+// activity processor only evaluates the handful of badges an event can affect.
+const BADGES_BY_METRIC = (() => {
+  const index = new Map();
+  for (const badge of BADGES) {
+    const metric = badge.criteria?.metric;
+    if (!metric) continue;
+    if (!index.has(metric)) index.set(metric, []);
+    index.get(metric).push(badge);
+  }
+  return index;
+})();
+
+// Meta badges are re-evaluated whenever any of their dependency badges is earned.
+export const META_BADGES = BADGES.filter((b) => b.criteria?.type === 'meta');
+
+export const getBadge = (id) => BADGES_BY_ID.get(id);
+export const getBadgesForMetric = (metric) => BADGES_BY_METRIC.get(metric) ?? [];
+
+/**
+ * The set of DynamoDB counter keys a single activity event should increment.
+ * We always keep an ecosystem-wide counter and, when the activity names a
+ * service, a per-service counter, so both ecosystem and service-scoped badges
+ * can be satisfied from the same event.
+ *
+ * @returns {{ metric: string, unique: boolean, scoped: boolean, service?: string }[]}
+ */
+export const getCountersForActivity = (action, service) => {
+  const badges = getBadgesForMetric(action);
+  if (!badges.length) return [];
+
+  const wantsUnique = badges.some((b) => b.criteria.type === 'unique');
+  const wantsScoped = badges.some((b) => b.criteria.type === 'count' && b.criteria.service);
+
+  const counters = [{ metric: action, unique: wantsUnique, scoped: false }];
+  if (wantsScoped && service) {
+    counters.push({ metric: action, unique: false, scoped: true, service });
+  }
+  return counters;
+};
+
+/** DynamoDB sort key for a progress counter. */
+export const counterKey = ({ metric, unique, scoped, service }) => {
+  if (unique) return `unique#${metric}`;
+  if (scoped) return `progress#${service}#${metric}`;
+  return `progress#${metric}`;
+};
+
+/**
+ * Evaluate a badge's criteria against the user's current state.
+ *
+ * @param badge      the catalog badge definition
+ * @param counters   map of counterKey -> numeric value (progress counters / unique-set sizes)
+ * @param earnedIds  Set of badge ids the user has already earned (for meta badges)
+ */
+export const isEarned = (badge, counters, earnedIds) => {
+  const c = badge.criteria;
+  if (!c) return false;
+
+  switch (c.type) {
+    case 'count': {
+      const key = c.service
+        ? `progress#${c.service}#${c.metric}`
+        : `progress#${c.metric}`;
+      return (counters[key] ?? 0) >= c.threshold;
+    }
+    case 'unique': {
+      return (counters[`unique#${c.metric}`] ?? 0) >= c.threshold;
+    }
+    case 'meta': {
+      const have = c.badges.filter((id) => earnedIds.has(id)).length;
+      return have >= (c.threshold ?? c.badges.length);
+    }
+    default:
+      return false;
+  }
+};
+
+/** Resolve a total point count to its level definition. */
+export const computeLevel = (points) => {
+  let current = LEVELS[0];
+  for (const level of LEVELS) {
+    if (points >= level.minPoints) current = level;
+    else break;
+  }
+  return current;
+};
+
+/** The next level a user is working toward, plus how many points remain (null at max). */
+export const getNextLevel = (points) => {
+  const next = LEVELS.find((l) => l.minPoints > points);
+  if (!next) return null;
+  return { ...next, pointsToGo: next.minPoints - points };
+};
+
+/** Public-facing view of a badge definition (hides internal criteria wiring). */
+export const toPublicBadge = (badge) => ({
+  id: badge.id,
+  name: badge.name,
+  description: badge.description,
+  icon: badge.icon,
+  category: badge.category,
+  tier: badge.tier,
+  points: badge.points,
+  ...(badge.service && { service: badge.service })
+});

--- a/template.yaml
+++ b/template.yaml
@@ -351,12 +351,16 @@ Resources:
   # Badge Chest — cross-app gamification (badges, points, levels)
   #
   # Apps emit "Track Activity" events to the default bus (or POST them to the
-  # BadgesApi). ProcessActivityFunction is the rules engine: it counts activity,
+  # CoreApi). ProcessActivityFunction is the rules engine: it counts activity,
   # awards badges from the central catalog, rolls points up into levels, and
-  # emits "Badge Awarded" / "Level Up" events. The BadgesApi is the read surface
-  # behind the shared Cognito user pool.
+  # emits "Badge Awarded" / "Level Up" events. The badge routes are served by
+  # the shared CoreApi behind the Cognito user pool.
+  #
+  # CoreApi is the shared public API surface for rsc-core (badges today, more
+  # core routes over time). In prod it is fronted by api.${RootDomainName}
+  # (e.g. api.readysetcloud.io); non-prod uses the execute-api URL.
   # ----------------------------------------------------------------------------
-  BadgesApi:
+  CoreApi:
     Type: AWS::Serverless::HttpApi
     Properties:
       Auth:
@@ -445,7 +449,7 @@ Resources:
         RecordActivity:
           Type: HttpApi
           Properties:
-            ApiId: !Ref BadgesApi
+            ApiId: !Ref CoreApi
             Path: /badges/activity
             Method: POST
 
@@ -474,7 +478,7 @@ Resources:
         GetChest:
           Type: HttpApi
           Properties:
-            ApiId: !Ref BadgesApi
+            ApiId: !Ref CoreApi
             Path: /badges/me
             Method: GET
 
@@ -493,19 +497,22 @@ Resources:
         GetCatalog:
           Type: HttpApi
           Properties:
-            ApiId: !Ref BadgesApi
+            ApiId: !Ref CoreApi
             Path: /badges/catalog
             Method: GET
             Auth:
               Authorizer: NONE
 
-  BadgesApiUrlParameter:
+  CoreApiUrlParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: /readysetcloud/badges/api-url
+      Name: /readysetcloud/api-url
       Type: String
-      Value: !Sub https://${BadgesApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
-      Description: Base URL of the Badge Chest HTTP API
+      Value: !If
+        - DeployCustomDomainSupport
+        - !Sub https://api.${RootDomainName}
+        - !Sub https://${CoreApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+      Description: Base URL of the shared rsc-core HTTP API (badge routes under /badges)
 
   Secrets:
     Type: AWS::SecretsManager::Secret
@@ -649,6 +656,46 @@ Resources:
         - !GetAtt CognitoUserPoolDomain.CloudFrontDistribution
       TTL: 300
       Type: CNAME
+
+  # Custom domain for the shared CoreApi — api.${RootDomainName} in prod.
+  ApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: DeployCustomDomainSupport
+    Properties:
+      DomainName: !Sub api.${RootDomainName}
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub api.${RootDomainName}
+          HostedZoneId: !Ref HostedZoneId
+
+  CoreApiDomainName:
+    Type: AWS::ApiGatewayV2::DomainName
+    Condition: DeployCustomDomainSupport
+    Properties:
+      DomainName: !Sub api.${RootDomainName}
+      DomainNameConfigurations:
+        - CertificateArn: !Ref ApiCertificate
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+
+  CoreApiMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Condition: DeployCustomDomainSupport
+    Properties:
+      ApiId: !Ref CoreApi
+      DomainName: !Ref CoreApiDomainName
+      Stage: $default
+
+  CoreApiDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: DeployCustomDomainSupport
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub api.${RootDomainName}
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt CoreApiDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt CoreApiDomainName.RegionalHostedZoneId
 
   CognitoUserPoolClient:
     Type: AWS::Cognito::UserPoolClient

--- a/template.yaml
+++ b/template.yaml
@@ -92,6 +92,9 @@ Resources:
           AttributeType: S
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
 
   TableStreamFunction:
     Type: AWS::Serverless::Function
@@ -147,6 +150,9 @@ Resources:
             - Effect: Allow
               Action: dynamodb:PutItem
               Resource: !GetAtt RSCCoreTable.Arn
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
       Environment:
         Variables:
           TABLE_NAME: !Ref RSCCoreTable
@@ -340,6 +346,166 @@ Resources:
             Pattern:
               detail-type:
                 - Send Email
+
+  # ----------------------------------------------------------------------------
+  # Badge Chest — cross-app gamification (badges, points, levels)
+  #
+  # Apps emit "Track Activity" events to the default bus (or POST them to the
+  # BadgesApi). ProcessActivityFunction is the rules engine: it counts activity,
+  # awards badges from the central catalog, rolls points up into levels, and
+  # emits "Badge Awarded" / "Level Up" events. The BadgesApi is the read surface
+  # behind the shared Cognito user pool.
+  # ----------------------------------------------------------------------------
+  BadgesApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        Authorizers:
+          CognitoJwt:
+            IdentitySource: $request.header.Authorization
+            JwtConfiguration:
+              issuer: !Sub https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPool}
+              audience:
+                - !Ref CognitoUserPoolClient
+        DefaultAuthorizer: CognitoJwt
+      CorsConfiguration:
+        AllowOrigins:
+          - '*'
+        AllowHeaders:
+          - authorization
+          - content-type
+        AllowMethods:
+          - GET
+          - POST
+          - OPTIONS
+
+  BadgeProcessorDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+
+  ProcessActivityFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - process-activity.mjs
+    Properties:
+      Handler: process-activity.handler
+      Timeout: 15
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt BadgeProcessorDLQ.Arn
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+                - dynamodb:GetItem
+                - dynamodb:Query
+              Resource: !GetAtt RSCCoreTable.Arn
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref RSCCoreTable
+      Events:
+        TrackActivity:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              detail-type:
+                - Track Activity
+
+  RecordActivityFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - record-activity.mjs
+    Properties:
+      Handler: record-activity.handler
+      Timeout: 5
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+      Events:
+        RecordActivity:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref BadgesApi
+            Path: /badges/activity
+            Method: POST
+
+  GetBadgeChestFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - get-badge-chest.mjs
+    Properties:
+      Handler: get-badge-chest.handler
+      Timeout: 5
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: dynamodb:Query
+              Resource: !GetAtt RSCCoreTable.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref RSCCoreTable
+      Events:
+        GetChest:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref BadgesApi
+            Path: /badges/me
+            Method: GET
+
+  GetBadgeCatalogFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - get-badge-catalog.mjs
+    Properties:
+      Handler: get-badge-catalog.handler
+      Timeout: 5
+      Events:
+        GetCatalog:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref BadgesApi
+            Path: /badges/catalog
+            Method: GET
+            Auth:
+              Authorizer: NONE
+
+  BadgesApiUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/badges/api-url
+      Type: String
+      Value: !Sub https://${BadgesApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+      Description: Base URL of the Badge Chest HTTP API
 
   Secrets:
     Type: AWS::SecretsManager::Secret

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -143,8 +143,9 @@ import { BadgeChest, createBadgeClient } from '@readysetcloud/ui';
 import { useAuth } from '@readysetcloud/ui/auth';
 
 const badges = createBadgeClient({
-  baseUrl: import.meta.env.VITE_BADGES_API_URL, // rsc-core SSM /readysetcloud/badges/api-url
-  getToken                                      // from useAuth()
+  baseUrl: import.meta.env.VITE_CORE_API_URL, // rsc-core SSM /readysetcloud/api-url
+                                              // (prod: https://api.readysetcloud.io)
+  getToken                                    // from useAuth()
 });
 
 const data = await badges.getChest();           // GET /badges/me

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -73,6 +73,7 @@ All components are typed, accept `className`, and forward standard HTML props.
 | `EmptyState` | `title`, `description?`, `icon?`, `action?` | |
 | `Container` | div props | max 72rem, fluid padding. |
 | `AppNav` | `appName`, `navItems`, `layout`, `currentServiceId`, `authState`, `services`, auth actions | Shared navbar: hardcoded ReadySetCloud cloud mark, configurable Raleway app name, Manrope nav labels, theme toggle, authenticated-only 9-box app launcher, optional auth controls. `layout="side"` renders a vertical rail (per-item `icon` + grouped `section` headings); default `top` is the horizontal bar. |
+| `BadgeChest` | `points`, `level`, `levelName`, `levelMinPoints`, `nextLevel`, `badges`, `inProgress`, `loading`, `showInProgress`, `emptyState` | Cross-app trophy case: level + points header with progress bar, earned badge grid, and in-progress tiles. Presentational — fetch with `createBadgeClient` and pass the data in. |
 | `cx(...parts)` | | Classname join helper (replaces clsx for simple cases). |
 
 ## Shared navbar and app registry
@@ -129,6 +130,38 @@ Default `readySetCloudServices` manifest:
 | `outboxed` | Outboxed | `https://newsletter.readysetcloud.io` |
 | `bootcamp` | Bootcamp | `https://bootcamp.readysetcloud.io` |
 | `olivias-garden-foundation` | Olivia's Garden Foundation | `https://oliviasgarden.org` |
+
+## Badges / gamification — `import { BadgeChest, createBadgeClient } from '@readysetcloud/ui'`
+
+One badge chest spans every app (keyed on the shared Cognito `sub`). The
+rules engine, catalog, and API live in `rsc-core`; this package ships the read
+client and the presentational component so every app renders the chest
+identically.
+
+```tsx
+import { BadgeChest, createBadgeClient } from '@readysetcloud/ui';
+import { useAuth } from '@readysetcloud/ui/auth';
+
+const badges = createBadgeClient({
+  baseUrl: import.meta.env.VITE_BADGES_API_URL, // rsc-core SSM /readysetcloud/badges/api-url
+  getToken                                      // from useAuth()
+});
+
+const data = await badges.getChest();           // GET /badges/me
+<BadgeChest {...data} loading={loading} />;
+
+// record activity from the client (the rules engine decides if it earns a badge):
+await badges.recordActivity({ action: 'lesson.completed', service: 'bootcamp' });
+```
+
+- `createBadgeClient({ baseUrl, getToken?, fetch? })` → `getChest()`,
+  `getCatalog()`, `recordActivity()`. Framework-agnostic (just `fetch`), so the
+  vanilla course pages and server code can use it too.
+- `BadgeChest` is data-in/render-out — spread the `getChest()` response onto it.
+  Pass `loading` for skeletons, `emptyState` to override the "no badges" copy,
+  and `showInProgress={false}` to hide locked badges.
+- Backend contract, catalog format, and how to add a badge live in the
+  `rsc-core` root README.
 
 ## Auth — `import { ... } from '@readysetcloud/ui/auth'`
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/ui",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
   "license": "MIT",
   "type": "module",

--- a/ui/src/badges/client.test.ts
+++ b/ui/src/badges/client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBadgeClient } from './client';
+
+const okJson = (body: unknown) =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+
+describe('createBadgeClient', () => {
+  it('sends the bearer token on per-user requests', async () => {
+    const fetchMock = vi.fn((_url: string, _init: RequestInit) => okJson({ points: 10 }));
+    const client = createBadgeClient({
+      baseUrl: 'https://api.example.com/',
+      getToken: () => 'tok-123',
+      fetch: fetchMock as unknown as typeof fetch
+    });
+
+    await client.getChest();
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.example.com/badges/me');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123');
+  });
+
+  it('does not send auth on the public catalog request', async () => {
+    const fetchMock = vi.fn((_url: string, _init: RequestInit) => okJson({ version: 1, badges: [], levels: [] }));
+    const client = createBadgeClient({
+      baseUrl: 'https://api.example.com',
+      getToken: () => 'tok-123',
+      fetch: fetchMock as unknown as typeof fetch
+    });
+
+    await client.getCatalog();
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.example.com/badges/catalog');
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('posts activity payloads as JSON', async () => {
+    const fetchMock = vi.fn((_url: string, _init: RequestInit) => okJson({ id: 'evt-1' }));
+    const client = createBadgeClient({
+      baseUrl: 'https://api.example.com',
+      getToken: async () => 'tok-123',
+      fetch: fetchMock as unknown as typeof fetch
+    });
+
+    const result = await client.recordActivity({ action: 'lesson.completed', service: 'bootcamp' });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.example.com/badges/activity');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ action: 'lesson.completed', service: 'bootcamp' });
+    expect(result).toEqual({ id: 'evt-1' });
+  });
+
+  it('throws on a non-ok response', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) } as Response)
+    );
+    const client = createBadgeClient({
+      baseUrl: 'https://api.example.com',
+      fetch: fetchMock as unknown as typeof fetch
+    });
+
+    await expect(client.getCatalog()).rejects.toThrow(/500/);
+  });
+});

--- a/ui/src/badges/client.ts
+++ b/ui/src/badges/client.ts
@@ -1,0 +1,62 @@
+import type { ActivityInput, BadgeCatalog, BadgeChestData } from './types';
+
+export interface BadgeClientOptions {
+  /**
+   * Base URL of the Badge Chest API. In apps this comes from the rsc-core SSM
+   * parameter `/readysetcloud/badges/api-url`.
+   */
+  baseUrl: string;
+  /**
+   * Returns a valid Cognito id token for the signed-in user. Required for the
+   * per-user endpoints (chest, record activity); pass `useAuth().getToken`.
+   */
+  getToken?: () => Promise<string | null | undefined> | string | null | undefined;
+  /** Override the fetch implementation (tests, SSR). Defaults to global fetch. */
+  fetch?: typeof fetch;
+}
+
+export interface BadgeClient {
+  /** The signed-in user's chest — earned badges, points, level, progress. */
+  getChest(): Promise<BadgeChestData>;
+  /** The public catalog of every earnable badge and the level ladder. */
+  getCatalog(): Promise<BadgeCatalog>;
+  /** Record an activity; the rules engine decides whether it earns a badge. */
+  recordActivity(activity: ActivityInput): Promise<{ id: string }>;
+}
+
+/**
+ * Creates a small client for the rsc-core Badge Chest API. Framework-agnostic
+ * (just `fetch`), so it works in React apps, the vanilla course pages, and on
+ * the server.
+ */
+export function createBadgeClient(options: BadgeClientOptions): BadgeClient {
+  const doFetch = options.fetch ?? globalThis.fetch;
+  const base = options.baseUrl.replace(/\/$/, '');
+
+  const authHeader = async (): Promise<Record<string, string>> => {
+    const token = typeof options.getToken === 'function' ? await options.getToken() : options.getToken;
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  };
+
+  const request = async <T>(path: string, init?: RequestInit & { auth?: boolean }): Promise<T> => {
+    const headers: Record<string, string> = { ...(init?.headers as Record<string, string>) };
+    if (init?.auth !== false) Object.assign(headers, await authHeader());
+
+    const res = await doFetch(`${base}${path}`, { ...init, headers });
+    if (!res.ok) {
+      throw new Error(`Badge API ${path} failed: ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+  };
+
+  return {
+    getChest: () => request<BadgeChestData>('/badges/me'),
+    getCatalog: () => request<BadgeCatalog>('/badges/catalog', { auth: false }),
+    recordActivity: (activity) =>
+      request<{ id: string }>('/badges/activity', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(activity)
+      })
+  };
+}

--- a/ui/src/badges/types.ts
+++ b/ui/src/badges/types.ts
@@ -1,0 +1,74 @@
+// Shared types for the cross-app badge chest. These mirror the JSON returned by
+// the rsc-core Badge Chest API (get-badge-chest / get-badge-catalog).
+
+export type BadgeTier = 'bronze' | 'silver' | 'gold' | 'platinum';
+
+/** A badge definition as it appears in the public catalog. */
+export interface BadgeDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  category?: string;
+  tier?: BadgeTier;
+  points: number;
+  /** The app this badge belongs to, if it is service-specific. */
+  service?: string;
+}
+
+/** A badge the user has unlocked. */
+export interface EarnedBadge extends BadgeDefinition {
+  /** ISO timestamp the badge was awarded. */
+  earnedDate?: string;
+}
+
+/** A badge the user is progressing toward but has not unlocked. */
+export interface InProgressBadge extends BadgeDefinition {
+  current: number;
+  threshold: number;
+}
+
+export interface LevelDefinition {
+  level: number;
+  name: string;
+  minPoints: number;
+}
+
+export interface NextLevel extends LevelDefinition {
+  /** Points remaining until this level is reached. */
+  pointsToGo: number;
+}
+
+/** The full response from GET /badges/me. */
+export interface BadgeChestData {
+  points: number;
+  level: number;
+  levelName?: string;
+  /** Point floor of the current level — used to draw the progress bar. */
+  levelMinPoints?: number;
+  nextLevel?: NextLevel | null;
+  badgeCount: number;
+  badges: EarnedBadge[];
+  inProgress: InProgressBadge[];
+}
+
+/** The full response from GET /badges/catalog. */
+export interface BadgeCatalog {
+  version: number;
+  badges: BadgeDefinition[];
+  levels: LevelDefinition[];
+}
+
+/** Payload for recording an activity via POST /badges/activity. */
+export interface ActivityInput {
+  /** The metric name, e.g. "lesson.completed" or "service.visited". */
+  action: string;
+  /** How much to increment by (default 1). */
+  count?: number;
+  /** Distinct dimension value for "unique" badges (e.g. a service id). */
+  value?: string;
+  /** The app emitting the activity. */
+  service?: string;
+  /** Idempotency key — reuse across retries to avoid double counting. */
+  id?: string;
+}

--- a/ui/src/components/BadgeChest.test.tsx
+++ b/ui/src/components/BadgeChest.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BadgeChest } from './BadgeChest';
+import type { EarnedBadge, InProgressBadge } from '../badges/types';
+
+afterEach(cleanup);
+
+const earned: EarnedBadge[] = [
+  { id: 'welcome', name: 'Welcome Aboard', icon: '🎉', tier: 'bronze', points: 10 }
+];
+const inProgress: InProgressBadge[] = [
+  { id: 'explorer', name: 'Ecosystem Explorer', icon: '🧭', tier: 'gold', points: 100, current: 2, threshold: 5 }
+];
+
+describe('BadgeChest', () => {
+  it('renders level, points, and earned badges', () => {
+    render(
+      <BadgeChest
+        points={60}
+        level={2}
+        levelName="Cloud Explorer"
+        levelMinPoints={50}
+        nextLevel={{ level: 3, name: 'Cloud Builder', minPoints: 150, pointsToGo: 90 }}
+        badges={earned}
+        inProgress={inProgress}
+      />
+    );
+
+    expect(screen.getByText('Welcome Aboard')).toBeDefined();
+    expect(screen.getByText('60')).toBeDefined();
+    expect(screen.getByText(/Cloud Explorer/)).toBeDefined();
+    expect(screen.getByText(/90 pts to Cloud Builder/)).toBeDefined();
+    expect(screen.getByText('Ecosystem Explorer')).toBeDefined();
+    expect(screen.getByText('2/5')).toBeDefined();
+  });
+
+  it('fills the progress bar based on points within the level band', () => {
+    render(
+      <BadgeChest
+        points={100}
+        level={2}
+        levelMinPoints={50}
+        nextLevel={{ level: 3, name: 'Cloud Builder', minPoints: 150, pointsToGo: 50 }}
+        badges={earned}
+      />
+    );
+
+    // (100 - 50) / (150 - 50) = 50%
+    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  it('shows the empty state when nothing is earned or in progress', () => {
+    render(<BadgeChest points={0} level={1} badges={[]} inProgress={[]} />);
+    expect(screen.getByText(/go earn your first one/i)).toBeDefined();
+  });
+
+  it('reports max level when there is no next level', () => {
+    render(<BadgeChest points={700} level={5} levelName="Cloud Sage" nextLevel={null} badges={earned} />);
+    expect(screen.getByText(/Max level reached/)).toBeDefined();
+    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('100');
+  });
+});

--- a/ui/src/components/BadgeChest.tsx
+++ b/ui/src/components/BadgeChest.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from 'react';
+import { cx } from './cx';
+import { Skeleton } from './Skeleton';
+import type { EarnedBadge, InProgressBadge, NextLevel } from '../badges/types';
+
+export interface BadgeChestProps {
+  /** Total points earned across every app. */
+  points: number;
+  /** Current level number. */
+  level: number;
+  /** Current level name, e.g. "Cloud Builder". */
+  levelName?: string;
+  /** Point floor of the current level (from the chest API). */
+  levelMinPoints?: number;
+  /** The level the user is working toward, or null at max level. */
+  nextLevel?: NextLevel | null;
+  /** Unlocked badges. */
+  badges: EarnedBadge[];
+  /** Badges the user is progressing toward. */
+  inProgress?: InProgressBadge[];
+  /** Hide the "in progress" section. Defaults to showing it. */
+  showInProgress?: boolean;
+  /** Render skeletons instead of content while the chest loads. */
+  loading?: boolean;
+  /** Shown when the user has earned no badges yet. */
+  emptyState?: ReactNode;
+  /** Heading text. Defaults to "Badge Chest". */
+  title?: ReactNode;
+  className?: string;
+}
+
+const tierClass = (tier?: string) => (tier ? `badge-tile--${tier}` : 'badge-tile--bronze');
+
+/**
+ * The shared cross-app trophy case. Renders a user's level, point total,
+ * progress to the next level, unlocked badges, and (optionally) badges in
+ * progress. Presentational — fetch the data with `createBadgeClient` and pass
+ * it in, so every app renders the chest identically.
+ */
+export function BadgeChest({
+  points,
+  level,
+  levelName,
+  levelMinPoints = 0,
+  nextLevel,
+  badges,
+  inProgress = [],
+  showInProgress = true,
+  loading = false,
+  emptyState,
+  title = 'Badge Chest',
+  className
+}: BadgeChestProps) {
+  const pct = nextLevel
+    ? Math.max(0, Math.min(100, ((points - levelMinPoints) / (nextLevel.minPoints - levelMinPoints)) * 100))
+    : 100;
+
+  return (
+    <section className={cx('card', 'badge-chest', className)} aria-label="Badge chest">
+      <header className="badge-chest-header">
+        <div className="badge-chest-heading">
+          <span className="badge-chest-title">{title}</span>
+          <span className="badge-chest-level">
+            Lv.{level}
+            {levelName ? ` · ${levelName}` : ''}
+          </span>
+        </div>
+        <div className="badge-chest-points">
+          <strong>{points.toLocaleString()}</strong> pts
+        </div>
+        <div
+          className="badge-chest-progress"
+          role="progressbar"
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <span className="badge-chest-progress-bar" style={{ width: `${pct}%` }} />
+        </div>
+        <p className="badge-chest-next">
+          {nextLevel
+            ? `${nextLevel.pointsToGo.toLocaleString()} pts to ${nextLevel.name}`
+            : 'Max level reached'}
+        </p>
+      </header>
+
+      <div className="badge-chest-body">
+        {loading ? (
+          <div className="badge-chest-grid">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} height="6.5rem" />
+            ))}
+          </div>
+        ) : badges.length === 0 && (!showInProgress || inProgress.length === 0) ? (
+          emptyState ?? (
+            <p className="badge-chest-empty">No badges yet — go earn your first one!</p>
+          )
+        ) : (
+          <>
+            {badges.length > 0 && (
+              <div className="badge-chest-grid">
+                {badges.map((badge) => (
+                  <EarnedTile key={badge.id} badge={badge} />
+                ))}
+              </div>
+            )}
+
+            {showInProgress && inProgress.length > 0 && (
+              <>
+                <h4 className="badge-chest-section">In progress</h4>
+                <div className="badge-chest-grid">
+                  {inProgress.map((badge) => (
+                    <LockedTile key={badge.id} badge={badge} />
+                  ))}
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EarnedTile({ badge }: { badge: EarnedBadge }) {
+  return (
+    <div className={cx('badge-tile', tierClass(badge.tier))} title={badge.description}>
+      <span className="badge-tile-icon" aria-hidden="true">
+        {badge.icon ?? '🏅'}
+      </span>
+      <span className="badge-tile-name">{badge.name}</span>
+      <span className="badge-tile-points">+{badge.points}</span>
+    </div>
+  );
+}
+
+function LockedTile({ badge }: { badge: InProgressBadge }) {
+  const pct = badge.threshold > 0 ? Math.min(100, (badge.current / badge.threshold) * 100) : 0;
+  return (
+    <div className="badge-tile badge-tile--locked" title={badge.description}>
+      <span className="badge-tile-icon" aria-hidden="true">
+        {badge.icon ?? '🔒'}
+      </span>
+      <span className="badge-tile-name">{badge.name}</span>
+      <div className="badge-tile-progress" aria-hidden="true">
+        <span className="badge-tile-progress-bar" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="badge-tile-points">
+        {badge.current}/{badge.threshold}
+      </span>
+    </div>
+  );
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -50,3 +50,16 @@ export {
   type RscServiceAccess,
   type RscServiceRegistry
 } from './services/registry';
+export { BadgeChest, type BadgeChestProps } from './components/BadgeChest';
+export { createBadgeClient, type BadgeClient, type BadgeClientOptions } from './badges/client';
+export type {
+  ActivityInput,
+  BadgeCatalog,
+  BadgeChestData,
+  BadgeDefinition,
+  BadgeTier,
+  EarnedBadge,
+  InProgressBadge,
+  LevelDefinition,
+  NextLevel
+} from './badges/types';

--- a/ui/styles/components.css
+++ b/ui/styles/components.css
@@ -932,3 +932,160 @@
   letter-spacing: 0.35em;
   text-align: center;
 }
+
+/* ---------- badge chest (gamification) ---------- */
+
+.badge-chest {
+  overflow: hidden;
+}
+
+.badge-chest-header {
+  padding: 1.125rem;
+  border-bottom: 1px solid rgb(var(--border));
+  background: linear-gradient(135deg, rgb(var(--primary-500) / 0.10), rgb(var(--surface)));
+}
+
+.badge-chest-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.badge-chest-title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.badge-chest-level {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: rgb(var(--primary-700));
+  font-weight: 600;
+}
+
+.badge-chest-points {
+  font-size: 0.8125rem;
+  color: rgb(var(--muted-foreground));
+  margin-top: 0.125rem;
+}
+
+.badge-chest-points strong {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  color: rgb(var(--foreground));
+}
+
+.badge-chest-progress {
+  margin-top: 0.625rem;
+  height: 0.5rem;
+  border-radius: var(--radius-full);
+  background: rgb(var(--muted));
+  overflow: hidden;
+}
+
+.badge-chest-progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-full);
+  background: rgb(var(--primary-500));
+  transition: width 0.4s ease;
+}
+
+.badge-chest-next {
+  margin: 0.375rem 0 0;
+  font-size: 0.6875rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.badge-chest-body {
+  padding: 1.125rem;
+}
+
+.badge-chest-section {
+  font-family: var(--font-display);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: rgb(var(--muted-foreground));
+  margin: 1.25rem 0 0.625rem;
+}
+
+.badge-chest-empty {
+  font-size: 0.875rem;
+  color: rgb(var(--muted-foreground));
+  text-align: center;
+  padding: 1.5rem 0;
+  margin: 0;
+}
+
+.badge-chest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(6.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.badge-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  border: 1px solid rgb(var(--border));
+  border-top: 3px solid rgb(var(--muted-foreground));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--surface));
+}
+
+.badge-tile--bronze { border-top-color: #cd7f32; }
+.badge-tile--silver { border-top-color: #9aa4af; }
+.badge-tile--gold { border-top-color: #f5b301; }
+.badge-tile--platinum { border-top-color: #5eead4; }
+
+.badge-tile-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.badge-tile-name {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgb(var(--foreground));
+  line-height: 1.2;
+}
+
+.badge-tile-points {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: rgb(var(--success-600));
+}
+
+.badge-tile--locked {
+  background: rgb(var(--muted));
+  border-top-color: rgb(var(--border));
+  opacity: 0.85;
+}
+
+.badge-tile--locked .badge-tile-icon {
+  filter: grayscale(1);
+  opacity: 0.7;
+}
+
+.badge-tile--locked .badge-tile-points {
+  color: rgb(var(--muted-foreground));
+}
+
+.badge-tile-progress {
+  width: 100%;
+  height: 0.25rem;
+  border-radius: var(--radius-full);
+  background: rgb(var(--border));
+  overflow: hidden;
+}
+
+.badge-tile-progress-bar {
+  display: block;
+  height: 100%;
+  background: rgb(var(--primary-500));
+}


### PR DESCRIPTION
Introduce an ecosystem-wide "badge chest" keyed on the shared Cognito
identity, so badges, points, and levels earned in any RSC app roll up
into one profile in the shared core table.

Backend (rules engine + read API):
- functions/badges/catalog.json + levels.json: central, versioned badge
  catalog and level ladder (count / unique / meta criteria).
- functions/utils/badges.mjs: pure rules engine (metric->badge index,
  criteria evaluation, level calc).
- process-activity: EventBridge-driven rules engine — dedupes activity,
  increments counters, idempotently awards badges, rolls points into
  levels, emits "Badge Awarded" / "Level Up".
- record-activity / get-badge-chest / get-badge-catalog: HTTP API behind
  a Cognito JWT authorizer for recording activity and reading the chest.
- template.yaml: HttpApi + JWT authorizer, four functions, processor DLQ,
  table TTL for dedupe markers, and an SSM export of the API URL.
- add-tenant-post-confirmation now emits account.created so a new user
  earns their first badge on signup.

UI (@readysetcloud/ui, 0.4.0):
- BadgeChest presentational component, createBadgeClient read client, and
  shared types, with styles, tests, and exports.

Docs: architecture, event contract, and catalog format in the READMEs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RDQWaCEYBicikp1mbbkXuc