### PR TITLE
Add shared loading state components

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -71,6 +71,9 @@ All components are typed, accept `className`, and forward standard HTML props.
 | `Spinner` | span props | Inherits `currentColor`. |
 | `Skeleton` | `width`, `height` | Shimmer placeholder. |
 | `EmptyState` | `title`, `description?`, `icon?`, `action?` | |
+| `Loading`, `LoadingSpinner`, `LoadingPage`, `LoadingOverlay`, `InlineLoading`, `SkeletonLoader` | shared loading/placeholder props | Composed loading states built on `Spinner` and `Skeleton`; use these instead of app-local loaders. |
+| `ProgressIndicator` | `steps: { id, label, status, description? }[]` | Step status list for setup/verification flows. Status: `pending`, `in-progress`, `completed`, `failed`. |
+| `ErrorState` | `heading?`, `message`, `action?` | Standard retryable error block built on `Alert`. |
 | `Container` | div props | max 72rem, fluid padding. |
 | `AppNav` | `appName`, `navItems`, `layout`, `currentServiceId`, `authState`, `services`, auth actions | Shared navbar: hardcoded ReadySetCloud cloud mark, configurable Raleway app name, Manrope nav labels, theme toggle, authenticated-only 9-box app launcher, optional auth controls. `layout="side"` renders a vertical rail (per-item `icon` + grouped `section` headings); default `top` is the horizontal bar. |
 | `BadgeChest` | `points`, `level`, `levelName`, `levelMinPoints`, `nextLevel`, `badges`, `inProgress`, `loading`, `showInProgress`, `emptyState` | Cross-app trophy case: level + points header with progress bar, earned badge grid, and in-progress tiles. Presentational — fetch with `createBadgeClient` and pass the data in. |

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/ui",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
   "license": "MIT",
   "type": "module",

--- a/ui/src/components/LoadingStates.test.tsx
+++ b/ui/src/components/LoadingStates.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ErrorState,
+  InlineLoading,
+  Loading,
+  LoadingOverlay,
+  LoadingPage,
+  ProgressIndicator,
+  SkeletonLoader
+} from './LoadingStates';
+
+afterEach(cleanup);
+
+describe('LoadingStates', () => {
+  it('renders accessible loading copy', () => {
+    render(<Loading text="Loading subscribers..." />);
+
+    expect(screen.getByRole('status').textContent).toContain('Loading subscribers...');
+  });
+
+  it('renders page loading with default copy', () => {
+    render(<LoadingPage />);
+
+    expect(screen.getByText('Loading...')).toBeDefined();
+  });
+
+  it('swaps inline children for loading content', () => {
+    const { rerender } = render(
+      <InlineLoading isLoading={false} loadingText="Saving">
+        <span>Ready</span>
+      </InlineLoading>
+    );
+
+    expect(screen.getByText('Ready')).toBeDefined();
+
+    rerender(
+      <InlineLoading isLoading loadingText="Saving">
+        <span>Ready</span>
+      </InlineLoading>
+    );
+
+    expect(screen.queryByText('Ready')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('Saving');
+  });
+
+  it('overlays children only while loading', () => {
+    const { rerender } = render(
+      <LoadingOverlay isLoading={false} message="Loading senders">
+        <section>Sender form</section>
+      </LoadingOverlay>
+    );
+
+    expect(screen.getByText('Sender form')).toBeDefined();
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(
+      <LoadingOverlay isLoading message="Loading senders">
+        <section>Sender form</section>
+      </LoadingOverlay>
+    );
+
+    expect(screen.getByRole('status').textContent).toContain('Loading senders');
+  });
+
+  it('renders the requested number of skeleton rows', () => {
+    const { container } = render(<SkeletonLoader count={2} />);
+
+    expect(container.querySelectorAll('.skeleton-loader-row')).toHaveLength(2);
+  });
+
+  it('renders progress steps with status attributes', () => {
+    const { container } = render(
+      <ProgressIndicator
+        steps={[
+          { id: 'dns', label: 'DNS records', status: 'completed' },
+          { id: 'verify', label: 'Verify domain', status: 'in-progress', description: 'This can take a while.' },
+          { id: 'send', label: 'Send email', status: 'pending' }
+        ]}
+      />
+    );
+
+    expect(screen.getByText('DNS records')).toBeDefined();
+    expect(screen.getByText('This can take a while.')).toBeDefined();
+    expect(container.querySelector("[data-status='in-progress']")).toBeDefined();
+  });
+
+  it('renders retryable error state actions', () => {
+    const onRetry = vi.fn();
+
+    render(<ErrorState message="Could not load templates." action={{ label: 'Retry', onClick: onRetry }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(screen.getByRole('alert').textContent).toContain('Could not load templates.');
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/LoadingStates.tsx
+++ b/ui/src/components/LoadingStates.tsx
@@ -1,0 +1,172 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { Alert } from './Alert';
+import { Button } from './Button';
+import { cx } from './cx';
+import { Skeleton } from './Skeleton';
+import { Spinner } from './Spinner';
+
+export type LoadingSize = 'sm' | 'md' | 'lg';
+export type ProgressStepStatus = 'pending' | 'in-progress' | 'completed' | 'failed';
+
+export interface LoadingSpinnerProps extends HTMLAttributes<HTMLSpanElement> {
+  size?: LoadingSize;
+}
+
+export function LoadingSpinner({ size = 'md', className, ...rest }: LoadingSpinnerProps) {
+  return <Spinner className={cx(`loading-spinner-${size}`, className)} {...rest} />;
+}
+
+export interface LoadingProps extends HTMLAttributes<HTMLDivElement> {
+  size?: LoadingSize;
+  text?: ReactNode;
+}
+
+export function Loading({ size = 'md', text, className, ...rest }: LoadingProps) {
+  return (
+    <div className={cx('loading-state', className)} role="status" aria-live="polite" {...rest}>
+      <LoadingSpinner size={size} />
+      {text && <span className="loading-state-text">{text}</span>}
+    </div>
+  );
+}
+
+export interface LoadingPageProps extends HTMLAttributes<HTMLDivElement> {
+  text?: ReactNode;
+}
+
+export function LoadingPage({ text = 'Loading...', className, ...rest }: LoadingPageProps) {
+  return (
+    <div className={cx('loading-page', className)} {...rest}>
+      <Loading size="lg" text={text} />
+    </div>
+  );
+}
+
+export interface InlineLoadingProps extends HTMLAttributes<HTMLDivElement> {
+  isLoading: boolean;
+  loadingText?: ReactNode;
+  children: ReactNode;
+  size?: Exclude<LoadingSize, 'lg'>;
+}
+
+export function InlineLoading({
+  isLoading,
+  loadingText,
+  children,
+  size = 'sm',
+  className,
+  ...rest
+}: InlineLoadingProps) {
+  if (!isLoading) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={cx('inline-loading', className)} role="status" aria-live="polite" {...rest}>
+      <LoadingSpinner size={size} />
+      {loadingText && <span>{loadingText}</span>}
+    </div>
+  );
+}
+
+export interface LoadingOverlayProps extends HTMLAttributes<HTMLDivElement> {
+  isLoading: boolean;
+  message?: ReactNode;
+  children: ReactNode;
+}
+
+export function LoadingOverlay({
+  isLoading,
+  message = 'Loading...',
+  children,
+  className,
+  ...rest
+}: LoadingOverlayProps) {
+  return (
+    <div className={cx('loading-overlay-shell', className)} aria-busy={isLoading || undefined} {...rest}>
+      {children}
+      {isLoading && (
+        <div className="loading-overlay" role="status" aria-live="polite">
+          <LoadingSpinner size="lg" />
+          <span className="loading-state-text">{message}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface SkeletonLoaderProps extends HTMLAttributes<HTMLDivElement> {
+  count?: number;
+}
+
+export function SkeletonLoader({ count = 3, className, ...rest }: SkeletonLoaderProps) {
+  return (
+    <div className={cx('skeleton-loader', className)} aria-hidden="true" {...rest}>
+      {Array.from({ length: count }).map((_, index) => (
+        <div className="skeleton-loader-row" key={index}>
+          <Skeleton className="skeleton-loader-avatar" />
+          <div className="skeleton-loader-copy">
+            <Skeleton height="0.875rem" />
+            <Skeleton width="66%" height="0.75rem" />
+          </div>
+          <div className="skeleton-loader-actions">
+            <Skeleton width="5rem" height="1.5rem" />
+            <Skeleton width="2rem" height="2rem" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface ProgressStep {
+  id: string;
+  label: ReactNode;
+  status: ProgressStepStatus;
+  description?: ReactNode;
+}
+
+export interface ProgressIndicatorProps extends HTMLAttributes<HTMLDivElement> {
+  steps: ProgressStep[];
+}
+
+export function ProgressIndicator({ steps, className, ...rest }: ProgressIndicatorProps) {
+  return (
+    <div className={cx('progress-indicator', className)} {...rest}>
+      {steps.map((step) => (
+        <div className="progress-step" data-status={step.status} key={step.id}>
+          <span className="progress-step-icon" aria-hidden="true" />
+          <div className="progress-step-copy">
+            <span className="progress-step-label">{step.label}</span>
+            {step.description && <span className="progress-step-description">{step.description}</span>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface ErrorStateProps extends HTMLAttributes<HTMLDivElement> {
+  heading?: ReactNode;
+  message: ReactNode;
+  action?: {
+    label: ReactNode;
+    onClick: () => void;
+  };
+}
+
+export function ErrorState({ heading = 'Something went wrong', message, action, className, ...rest }: ErrorStateProps) {
+  return (
+    <Alert variant="error" className={cx('error-state', className)} {...rest}>
+      <div className="error-state-copy">
+        <strong>{heading}</strong>
+        <span>{message}</span>
+      </div>
+      {action && (
+        <Button type="button" variant="error" size="sm" onClick={action.onClick}>
+          {action.label}
+        </Button>
+      )}
+    </Alert>
+  );
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -39,6 +39,27 @@ export {
 export { ToastProvider, useToast, type ToastOptions, type ToastVariant } from './components/Toast';
 export { Skeleton, type SkeletonProps } from './components/Skeleton';
 export { EmptyState, type EmptyStateProps } from './components/EmptyState';
+export {
+  ErrorState,
+  InlineLoading,
+  Loading,
+  LoadingOverlay,
+  LoadingPage,
+  LoadingSpinner,
+  ProgressIndicator,
+  SkeletonLoader,
+  type ErrorStateProps,
+  type InlineLoadingProps,
+  type LoadingOverlayProps,
+  type LoadingPageProps,
+  type LoadingProps,
+  type LoadingSize,
+  type LoadingSpinnerProps,
+  type ProgressIndicatorProps,
+  type ProgressStep,
+  type ProgressStepStatus,
+  type SkeletonLoaderProps
+} from './components/LoadingStates';
 export { Container } from './components/Container';
 export {
   defineServiceRegistry,

--- a/ui/styles/components.css
+++ b/ui/styles/components.css
@@ -358,6 +358,212 @@
   color: rgb(var(--foreground));
 }
 
+/* ---------- loading states ---------- */
+
+.loading-spinner-sm { font-size: 1rem; }
+.loading-spinner-md { font-size: 1.5rem; }
+.loading-spinner-lg { font-size: 2rem; }
+
+.loading-state,
+.inline-loading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: rgb(var(--primary-600));
+}
+
+.loading-state {
+  flex-direction: column;
+  width: 100%;
+  min-height: 8rem;
+  padding: 1.5rem;
+}
+
+.loading-state-text {
+  color: rgb(var(--muted-foreground));
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.loading-page {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(var(--background));
+}
+
+.loading-overlay-shell {
+  position: relative;
+}
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: inherit;
+  background: rgb(var(--surface) / 0.82);
+  color: rgb(var(--primary-600));
+}
+
+.skeleton-loader {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.skeleton-loader-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--surface));
+}
+
+.skeleton-loader-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  border-radius: var(--radius-full);
+}
+
+.skeleton-loader-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton-loader-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.progress-indicator {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.progress-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.progress-step-icon {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: 0 0 auto;
+  margin-top: 0.125rem;
+  border: 2px solid rgb(var(--muted-foreground));
+  border-radius: var(--radius-full);
+}
+
+.progress-step[data-status='in-progress'] .progress-step-icon {
+  border-color: rgb(var(--primary-600));
+  border-right-color: transparent;
+  animation: rsc-spin 0.7s linear infinite;
+}
+
+.progress-step[data-status='completed'] .progress-step-icon {
+  border-color: rgb(var(--success-600));
+  background: rgb(var(--success-600));
+}
+
+.progress-step[data-status='completed'] .progress-step-icon::after {
+  content: '';
+  position: absolute;
+  left: 0.3125rem;
+  top: 0.125rem;
+  width: 0.3125rem;
+  height: 0.625rem;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.progress-step[data-status='failed'] .progress-step-icon {
+  border-color: rgb(var(--error-600));
+  background: rgb(var(--error-600));
+}
+
+.progress-step[data-status='failed'] .progress-step-icon::before,
+.progress-step[data-status='failed'] .progress-step-icon::after {
+  content: '';
+  position: absolute;
+  left: 0.25rem;
+  top: 0.5rem;
+  width: 0.625rem;
+  height: 2px;
+  background: #fff;
+}
+
+.progress-step[data-status='failed'] .progress-step-icon::before { transform: rotate(45deg); }
+.progress-step[data-status='failed'] .progress-step-icon::after { transform: rotate(-45deg); }
+
+.progress-step-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.progress-step-label {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: rgb(var(--muted-foreground));
+}
+
+.progress-step[data-status='in-progress'] .progress-step-label { color: rgb(var(--primary-700)); }
+.progress-step[data-status='completed'] .progress-step-label { color: rgb(var(--success-700)); }
+.progress-step[data-status='failed'] .progress-step-label { color: rgb(var(--error-700)); }
+
+.progress-step-description {
+  color: rgb(var(--muted-foreground));
+  font-size: 0.75rem;
+}
+
+.error-state {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.error-state-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+@media (max-width: 640px) {
+  .skeleton-loader-row {
+    align-items: flex-start;
+  }
+
+  .skeleton-loader-actions {
+    display: none;
+  }
+
+  .error-state {
+    flex-direction: column;
+  }
+}
+
 /* ---------- container ---------- */
 
 .container-rsc {


### PR DESCRIPTION
## Summary

Adds shared loading and state primitives to `@readysetcloud/ui` so downstream apps can replace local implementations called out in readysetcloud/newsletter-service#329.

- adds `Loading`, `LoadingSpinner`, `LoadingPage`, `LoadingOverlay`, `InlineLoading`, `SkeletonLoader`, `ProgressIndicator`, and `ErrorState`
- builds the composed states on the existing shared `Spinner`, `Skeleton`, `Alert`, and `Button` primitives
- exports and documents the new API, adds token-based CSS, and bumps the package to `0.4.1`

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`

## Notes

`npm install` reported one existing low-severity audit finding in the UI package dependency tree.