### PR TITLE
Propagate user identity to outbound MCP servers; parameterize MCP host allowlist (#196, #197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,18 @@ memory model, so any app can drop in a chat surface with
 1. **Configure a session.** A signed-in caller `POST /agent/sessions` (or
    backend code calls `createSession()` from `@readysetcloud/agent`) to create a
    session with an optional `systemPrompt`, `modelId`, `temperature`,
-   `maxTokens`, `title` — all defaulted when omitted. The row is stored at
-   `pk=SESSION#{id}, sk=CONFIG` and **owned by the verified caller**. This is the
-   knob for agent behavior: **the deployed runtime is a generic host, so changing
-   prompts or models is a data operation here, never a redeploy.**
+   `maxTokens`, `title`, first-party `tools`, and external `mcpServers` — all
+   defaulted/omitted when unset. The row is stored at `pk=SESSION#{id},
+   sk=CONFIG` and **owned by the verified caller**. This is the knob for agent
+   behavior: **the deployed runtime is a generic host, so changing prompts,
+   models, or tools is a data operation here, never a redeploy.** `mcpServers`
+   is the one place a session points the runtime at an outbound URL, so
+   `create-session` rejects any host not in `MCP_ALLOWED_HOSTS` (the
+   `McpAllowedHosts` parameter; empty rejects all — opt in explicitly) as an
+   SSRF guard. A spec's `authHeader` carries an authority-minted token that the
+   runtime forwards verbatim to that MCP server, propagating the verified user's
+   identity to a per-tenant tool — see the [package
+   README](agent/README.md#mcp-servers-external-tools).
 2. **Presign.** The browser calls `POST /agent/connect` with that `sessionId`.
    `WebSocketConnectFunction` returns a SigV4-presigned `wss://` URL to the
    AgentCore Runtime, carrying the verified Cognito `sub` as a custom header — so

--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -7,6 +7,7 @@ import {
   handleUserMessage,
   getSessionConfig,
   resolveTools,
+  type McpServerSpec,
   type ServerMessage,
   type ToolRegistry,
 } from '@readysetcloud/agent';
@@ -48,6 +49,33 @@ const TOOL_REGISTRY: ToolRegistry = {
       callback: async () => new Date().toISOString(),
     }),
 };
+
+/**
+ * Maps a session's declarative MCP specs to the Strands SDK's connection config,
+ * folding each spec's authority-minted `authHeader` into the outbound HTTP
+ * headers (rsc-core issue #197). The header carries the verified user's identity
+ * to the MCP server: the authority (session creator) signs the identity/scope
+ * server-side and stores the token on the spec; this runtime is a dumb courier
+ * that forwards it verbatim and never interprets it.
+ *
+ * `authHeader` is applied AFTER the user-supplied `headers`, so a session's own
+ * headers can't shadow the identity header. The token value is opaque (base64url
+ * payload + signature) and contains no `${...}`, so the SDK's env interpolation
+ * over header values leaves it untouched — it is passed through literally.
+ */
+function toMcpServerConfigs(
+  specs: Record<string, McpServerSpec>,
+): Record<string, McpServerConfig> {
+  const configs: Record<string, McpServerConfig> = {};
+  for (const [name, spec] of Object.entries(specs)) {
+    const { authHeader, ...rest } = spec;
+    if (authHeader?.name) {
+      rest.headers = { ...rest.headers, [authHeader.name]: authHeader.value };
+    }
+    configs[name] = rest as McpServerConfig;
+  }
+  return configs;
+}
 
 /** Best-effort disconnect of a session's MCP clients (never throws). */
 async function closeMcpClients(clients: McpClient[]): Promise<void> {
@@ -91,7 +119,7 @@ async function buildAgentForSession(
   let mcpClients: McpClient[] = [];
   const mcpServers = config?.mcpServers;
   if (mcpServers && Object.keys(mcpServers).length > 0) {
-    mcpClients = await McpClient.loadServers(mcpServers as Record<string, McpServerConfig>);
+    mcpClients = await McpClient.loadServers(toMcpServerConfigs(mcpServers));
   }
 
   const agent = createAssistant({

--- a/agent/README.md
+++ b/agent/README.md
@@ -25,7 +25,7 @@ Strands SDK and `zod`.
 | --- | --- |
 | `createAssistant({ sessionId, userId?, modelId?, systemPrompt?, temperature?, maxTokens?, tools?, storage? })` | Builds a Strands `Agent` with a DynamoDB session manager + `recall_memory` tool (added only when `userId` is set). |
 | `handleUserMessage(agent, { request, sessionId, userId?, send })` | Runs one turn: streams wire messages via `send`, records the turn to DynamoDB, returns the assistant text. |
-| `createSession({ userId, systemPrompt?, modelId?, temperature?, maxTokens?, title?, sessionId? })`, `getSessionConfig(sessionId)` | Per-session config so a generic host loads prompt/model by `sessionId` at connect (no redeploy to change behavior). `createSession` sets the owner; the host enforces it. Also on the `./memory` subpath. |
+| `createSession({ userId, systemPrompt?, modelId?, temperature?, maxTokens?, title?, tools?, mcpServers?, sessionId? })`, `getSessionConfig(sessionId)` | Per-session config so a generic host loads prompt/model/tools by `sessionId` at connect (no redeploy to change behavior). `createSession` sets the owner; the host enforces it. `tools` selects first-party tools by name; `mcpServers` attaches external MCP tool sources (see [MCP servers](#mcp-servers-external-tools)). Also on the `./memory` subpath. |
 | `streamTurn(stream, { sessionId, send })`, `toStreamEventBodies(event)` | Streaming primitives / the SDK→wire normalizer (the one SDK coupling point). |
 | `DynamoSnapshotStorage` | Implements Strands' `SnapshotStorage` port against the single table. |
 | `recordTurn`, `turnKey`, `TURN_ENTITY` | Conversation-turn rows. |
@@ -104,6 +104,88 @@ conversation. A session with no config row → package defaults. `createSession`
 is conditional on the session not already existing, so an owner can't be
 overwritten. The generated `sessionId` is a UUID (satisfies AgentCore's runtime
 session-id length requirement).
+
+## MCP servers (external tools)
+
+Beyond first-party `tools`, a session can attach external
+[MCP](https://modelcontextprotocol.io) servers — the one place a session points
+the runtime at an outbound URL. Each entry in `mcpServers` is an `McpServerSpec`
+(a JSON-serializable subset of the Strands SDK's `McpServerConfig`), keyed by a
+label:
+
+```ts
+await createSession({
+  userId,                              // verified caller — the session owner
+  mcpServers: {
+    blog: {
+      url: 'https://mcp.example.com/mcp',
+      headers: { 'x-api-version': '2025-01' },   // user-supplied; `${VAR}` interpolated by the host
+    },
+  },
+});
+```
+
+The host connects these at build time (`McpClient.loadServers`) and attaches
+their tools alongside the first-party ones. `${VAR}` / `${env:VAR}` in string
+fields is resolved by the SDK against the **host's** environment, so any secret
+belongs in the runtime env — not in this row (which the user creates).
+
+### SSRF allowlist — a host responsibility
+
+Because `mcpServers` is an outbound URL under user control, the **host** must
+allowlist which hosts a session may target before persisting the config — this
+package does not. In rsc-core, `functions/create-session.mjs` rejects any
+`mcpServers` whose url host is not in `MCP_ALLOWED_HOSTS` (comma-separated;
+empty rejects all, so it's opt-in), threaded from the `McpAllowedHosts`
+CloudFormation parameter. Add a host there before a session can reference it.
+
+### `authHeader` — propagating verified identity to an MCP server
+
+The SDK's env interpolation only reaches the *host's* env; it can't carry the
+**connecting user's** verified identity to an MCP server. That matters for a
+per-tenant tool (e.g. a blog search that must scope results to the asking user):
+the server needs to know (a) the caller is the trusted runtime and (b) *which*
+user is asking — and the config row, created by the user, is not a trusted place
+for a per-user secret.
+
+`McpServerSpec.authHeader` closes that gap:
+
+```ts
+mcpServers: {
+  blog: {
+    url: 'https://mcp.example.com/mcp',
+    authHeader: {
+      name: 'x-booked-auth',
+      value: '<base64url(payload)>.<sig>',   // authority-minted, opaque to the runtime
+    },
+  },
+}
+```
+
+- An **authority** (a trusted server-side session creator, *not* the browser)
+  mints the token: it signs the identity/scope it wants the server to trust —
+  e.g. `HMAC_SHA256(secret, `${tenantId}.${userId}.${sessionId}.${version}`)` —
+  with a secret only the authority and the MCP server hold, and stores
+  `{ name, value }` on the spec.
+- The **runtime is a dumb courier**: it forwards `value` verbatim as the named
+  outbound header on every request to that server and never interprets it.
+  `authHeader` is applied *after* the user-supplied `headers`, so a session's own
+  `headers` can't shadow it, and — unlike `headers` — it is passed through
+  **literally** (no `${}` interpolation); mint opaque tokens with no `${` in
+  them.
+- The **MCP server** verifies the token with the shared secret, then trusts the
+  claimed tenant/user.
+
+**Threat model (state it plainly):** the HMAC proves *"the authority minted this
+for user U"* — it does **not** cryptographically prove the presenter is this
+runtime. That's acceptable here because the config row isn't user-reachable, the
+host is allowlisted (above), and transport is TLS. Because the token is replayed
+on every reconnect over the session's ~30-day TTL it is effectively long-lived;
+bind it to the `sessionId` (so a leak can't move to another session) and include
+a `version` the authority can bump to revoke outstanding tokens without rotating
+the secret. A non-expiring, `sessionId`-bound, `version`-revocable token is a
+defensible posture for a tool that only reads the owner's own content — document
+the lifetime rather than implying a short-lived token.
 
 ## Wire protocol
 

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/agent",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1085.0",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Portable, framework-agnostic Node agent core for Ready, Set, Cloud: a Strands-TS assistant with DynamoDB-backed conversation history and semantic vector memory.",
   "author": "allenheltondev",
   "license": "MIT",

--- a/agent/src/memory/sessions.test.ts
+++ b/agent/src/memory/sessions.test.ts
@@ -74,6 +74,24 @@ describe('createSession', () => {
     });
   });
 
+  it('persists an authority-minted authHeader on an MCP server spec', async () => {
+    const mcpServers = {
+      blog: {
+        url: 'https://mcp.booked.example/mcp',
+        authHeader: { name: 'x-booked-auth', value: 'payload.sig' },
+      },
+    };
+    const config = await createSession({
+      userId: 'user-1',
+      sessionId: 'sess-3',
+      mcpServers,
+      now: 1,
+    });
+
+    expect(config.mcpServers).toEqual(mcpServers);
+    expect(send.mock.calls[0][0].input.Item).toMatchObject({ mcpServers });
+  });
+
   it('requires a userId', async () => {
     await expect(createSession({ userId: '' })).rejects.toThrow(/userId/);
     expect(send).not.toHaveBeenCalled();

--- a/agent/src/memory/sessions.ts
+++ b/agent/src/memory/sessions.ts
@@ -37,6 +37,28 @@ export interface McpServerSpec {
   url?: string;
   /** HTTP headers sent with every request. */
   headers?: Record<string, string>;
+  /**
+   * An authority-minted credential that travels with the session and identifies
+   * the verified connecting user to this MCP server. The session's creator (a
+   * trusted authority, server-side) signs the user's identity/scope and stores
+   * the resulting token here; the runtime forwards it verbatim as an outbound
+   * HTTP header on every request to this server, letting the server authenticate
+   * that the caller is the shared runtime and learn which user is asking (so it
+   * can scope retrieval to that user's tenant). See rsc-core issue #197.
+   *
+   * Distinct from {@link headers} on purpose: `headers` is user-supplied and
+   * subject to `${VAR}` interpolation, whereas this is an authority credential
+   * the runtime passes through literally (no interpolation) and applies last, so
+   * a session's own headers can't shadow it. Unlike other secrets, this one may
+   * live in the config row because it is bound to the session, revocable by the
+   * authority, and only grants a read of the user's own content.
+   */
+  authHeader?: {
+    /** Outbound header name the MCP server expects (authority-chosen). */
+    name: string;
+    /** Opaque authority-minted token (e.g. `<base64url(payload)>.<sig>`). */
+    value: string;
+  };
   /** Explicit transport; auto-detected from the fields present when omitted. */
   transport?: 'stdio' | 'sse' | 'streamable-http';
   /** Command to spawn (stdio transport). */

--- a/functions/create-session.mjs
+++ b/functions/create-session.mjs
@@ -16,6 +16,12 @@ import { createSession } from '@readysetcloud/agent/memory';
  * MCP servers are the one place a session can point the runtime at an outbound
  * URL, so each host is checked against the MCP_ALLOWED_HOSTS allowlist (an SSRF
  * guard). With the allowlist unset, `mcpServers` is rejected — opt in explicitly.
+ *
+ * A spec's optional `authHeader` ({ name, value }) is an authority-minted token
+ * that identifies the verified user to the MCP server; it is stored verbatim and
+ * acted on by the runtime (which forwards it as an outbound header) — this
+ * function neither interprets nor validates it. See the @readysetcloud/agent
+ * README ("MCP servers") for the token/threat model.
  */
 export const handler = async (event) => {
   const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;

--- a/template.yaml
+++ b/template.yaml
@@ -56,6 +56,14 @@ Parameters:
     Type: String
     Default: agent/agent.zip
     Description: S3 key (in the assets BucketName) of the packaged NODE_22 agent runtime artifact.
+  McpAllowedHosts:
+    Type: String
+    Default: ''
+    Description: >
+      Comma-separated hosts a session's mcpServers urls may target (SSRF
+      allowlist enforced by create-session). Empty (default) rejects any
+      mcpServers — opt in explicitly. Add Booked's MCP host here once its
+      server has a stable URL (issue #196).
 
 Metadata:
   esbuild-properties: &esbuild-properties
@@ -701,8 +709,8 @@ Resources:
         Variables:
           TABLE_NAME: !Ref AgentChatTable
           # Comma-separated hosts a session's MCP server urls may target. Empty
-          # (default) rejects any mcpServers — opt in by setting this.
-          MCP_ALLOWED_HOSTS: ''
+          # (default) rejects any mcpServers — set McpAllowedHosts to opt in.
+          MCP_ALLOWED_HOSTS: !Ref McpAllowedHosts
       Policies:
         - AWSLambdaBasicExecutionRole
         - Version: 2012-10-17


### PR DESCRIPTION
Implements #196 and #197 together — they share the session `mcpServers` surface.

## #197 — Propagate verified user identity to outbound MCP servers

The runtime previously connected to a session's MCP servers using only the SDK's static `${VAR}` interpolation against **its own** env — there was no way to pass the **verified connecting user's** identity to a session's MCP server. A per-tenant tool (e.g. Booked's `search_blog`) therefore couldn't authenticate the caller as the runtime or scope retrieval to the asking user.

Per the design decided in the issue thread (**option b — a first-class field**):

- **`agent/src/memory/sessions.ts`** — adds `authHeader?: { name: string; value: string }` to `McpServerSpec`. An authority (trusted, server-side) mints a token (e.g. an HMAC over `tenantId.userId.sessionId.version`) and stores it on the spec. Documented as distinct from user `headers`: authority-controlled, passed literally, session-bound, version-revocable.
- **`agent-runtime/src/index.ts`** — new `toMcpServerConfigs()` folds each spec's `authHeader` into the outbound HTTP headers **after** user-supplied `headers` (so a session can't shadow the identity header) and passes it through **verbatim** (no `${}` interpolation). The runtime stays a dumb courier — it never interprets the token.

Persistence needed no change: `createSession`/`getSessionConfig` already store and load `mcpServers` wholesale, so `authHeader` rides along inside each spec.

## #196 — Allowlist Booked's MCP host

- **`template.yaml`** — adds a `McpAllowedHosts` CloudFormation parameter (default `''` rejects all `mcpServers` — opt in explicitly) and wires `MCP_ALLOWED_HOSTS: !Ref McpAllowedHosts` into the CreateSession function's env, replacing the hardcoded `''`. A host can now be allowlisted at deploy time — no code change — once Booked's MCP server has a stable URL. The SSRF check in `create-session.mjs` was already correct and is unchanged.

## Documentation

Neither README documented `mcpServers` before. Added:
- **`agent/README.md`** — new "MCP servers (external tools)" section: the `McpServerSpec` shape, the host-side SSRF allowlist responsibility, and a full `authHeader` writeup with the honest threat model (the HMAC vouches for the authority's claim, not that the caller is the runtime; long-lived over the 30-day TTL, `sessionId`-bound and `version`-revocable).
- **`README.md`** — extended the "Configure a session" step to cover `tools`/`mcpServers`, the allowlist opt-in, and `authHeader`.
- Code comments in `sessions.ts`, `agent-runtime/src/index.ts`, and `create-session.mjs`.

## Reviewer notes

- **`create-session` does not validate or reject a caller-supplied `authHeader`** — by design. A user can't forge a valid HMAC without the authority's secret, so a spoofed header simply fails verification at the MCP server. If you'd prefer stripping/rejecting it from untrusted callers as defense-in-depth, that's a small follow-up.
- The `authHeader` token value is opaque (base64url payload + signature) and contains no `${`, so the SDK's header interpolation leaves it untouched — mint tokens accordingly.
- The deploy value for `McpAllowedHosts` still needs confirmation with the Booked side once its MCP server URL is stable (called out in #196).

## Verification

- Added an `authHeader` persistence round-trip test — **agent tests: 27 passed**.
- **Typecheck clean** for both `agent` and `agent-runtime`.

Closes #196
Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)