### PR TITLE
Fix Core API 401: read REST (v1) authorizer claims after the HttpApi migration

### DIFF
--- a/functions/create-session.mjs
+++ b/functions/create-session.mjs
@@ -24,7 +24,7 @@ import { createSession } from '@readysetcloud/agent/memory';
  * README ("MCP servers") for the token/threat model.
  */
 export const handler = async (event) => {
-  const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+  const userId = event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub;
   if (!userId) {
     return response(401, { message: 'Unauthorized' });
   }

--- a/functions/get-badge-chest.mjs
+++ b/functions/get-badge-chest.mjs
@@ -17,7 +17,7 @@ const TABLE_NAME = process.env.TABLE_NAME;
  * haven't unlocked yet. This is the single read the shared BadgeChest UI hits.
  */
 export const handler = async (event) => {
-  const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+  const userId = event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub;
   if (!userId) {
     return response(401, { message: 'Unauthorized' });
   }

--- a/functions/record-activity.mjs
+++ b/functions/record-activity.mjs
@@ -11,7 +11,7 @@ const eventBridge = new EventBridgeClient();
  * rules engine (process-activity) consumes.
  */
 export const handler = async (event) => {
-  const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+  const userId = event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub;
   if (!userId) {
     return response(401, { message: 'Unauthorized' });
   }

--- a/functions/websocket-connect.mjs
+++ b/functions/websocket-connect.mjs
@@ -56,7 +56,7 @@ const formatSignedUrl = (request) => {
 
 export const handler = async (event) => {
   try {
-    const userId = event.requestContext?.authorizer?.jwt?.claims?.sub;
+    const userId = event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub;
     if (!userId) {
       return response(401, { message: 'Unauthorized' });
     }


### PR DESCRIPTION
## The bug

`POST /agent/connect` (and the badges/activity endpoints) return **401 for every caller** — including the Booked dashboard trying to presign the agent WebSocket.

Cause: CoreApi was migrated from an HTTP API (v2) to a REST API (v1) ("Rename CoreApi → CoreRestApi to replace HttpApi resource"), but four handlers still read the caller identity from the **v2** authorizer shape:

```js
event.requestContext?.authorizer?.jwt?.claims?.sub   // v2 (HTTP API) only
```

On a REST (v1) API with a Cognito authorizer, claims are at `requestContext.authorizer.claims.sub` (no `.jwt`). So `sub` was always `undefined`, and each handler's `if (!userId) return 401` fired. (`update-tenant` was already on the v1 shape, which is why it wasn't affected.)

## The fix

Read the v1 shape first, fall back to v2, in the four affected handlers — correct on the current REST API and migration-safe:

```js
event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub
```

Files: `websocket-connect.mjs` (`/agent/connect`), `create-session.mjs` (`/agent/sessions`), `get-badge-chest.mjs`, `record-activity.mjs`. eslint clean.

## Impact

Unblocks the Booked "Ask your blog" chat (the widget can finally presign its WebSocket), and restores the badges/activity endpoints for all Core API consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
