### PR TITLE
Fix Core API CORS: add Access-Control-Allow-Origin to proxy responses (v1 migration)

### DIFF
--- a/functions/create-session.mjs
+++ b/functions/create-session.mjs
@@ -92,6 +92,6 @@ const validateMcpServers = (mcpServers) => {
 
 const response = (statusCode, body) => ({
   statusCode,
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
   body: JSON.stringify(body)
 });

--- a/functions/get-badge-catalog.mjs
+++ b/functions/get-badge-catalog.mjs
@@ -9,7 +9,7 @@ import { BADGES, LEVELS, CATALOG_VERSION, toPublicBadge } from './utils/badges.m
 export const handler = async () => ({
   statusCode: 200,
   headers: {
-    'Content-Type': 'application/json',
+    'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*',
     'Cache-Control': 'public, max-age=300'
   },
   body: JSON.stringify({

--- a/functions/get-badge-chest.mjs
+++ b/functions/get-badge-chest.mjs
@@ -117,6 +117,6 @@ const queryUser = async (userId) => {
 
 const response = (statusCode, body) => ({
   statusCode,
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
   body: JSON.stringify(body)
 });

--- a/functions/record-activity.mjs
+++ b/functions/record-activity.mjs
@@ -53,6 +53,6 @@ export const handler = async (event) => {
 
 const response = (statusCode, body) => ({
   statusCode,
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
   body: JSON.stringify(body)
 });

--- a/functions/websocket-connect.mjs
+++ b/functions/websocket-connect.mjs
@@ -122,6 +122,6 @@ export const handler = async (event) => {
 
 const response = (statusCode, body) => ({
   statusCode,
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
   body: JSON.stringify(body)
 });


### PR DESCRIPTION
## The bug

Cross-origin **POST** to the Core API (e.g. the Booked dashboard's `POST /agent/connect`) fails CORS — even though the **OPTIONS preflight succeeds and the POST itself returns 200**. The browser blocks reading the 200 because the response has no `Access-Control-Allow-Origin` header.

Same root cause as the 401 (#201): the HTTP API (v2) → REST API (v1) migration. An HTTP API auto-injects CORS headers on **every** response; a REST API with a **Lambda proxy** integration does not — the Lambda's own response headers are passed through verbatim. SAM's `Cors` config only wires the headers into the **OPTIONS** mock integration, which is why preflight works but the actual method response doesn't.

## The fix

Add `Access-Control-Allow-Origin: *` (matching the API-level `Cors` `AllowOrigin: '*'`) to the JSON responses of the Core API's browser-facing handlers: `websocket-connect`, `create-session`, `get-badge-chest`, `get-badge-catalog`, `record-activity`. Only `Allow-Origin` is needed on the actual response (preflight headers like Allow-Methods/Headers are already handled by the OPTIONS mock). eslint clean.

## Impact

Unblocks the Booked "Ask your blog" WebSocket presign, and restores CORS for the badges/activity endpoints for any cross-origin browser caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
