### PR TITLE
WebSocket: fall back to message user_id (fixes "Session does not belong to this user")

### DIFF
--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -180,7 +180,7 @@ const app = new BedrockAgentCoreApp({
     context.log.info({ userId, sessionId: context.sessionId }, 'WebSocket connected');
 
     socket.on('message', async (raw: Buffer) => {
-      let data: { request?: string; session_id?: string };
+      let data: { request?: string; session_id?: string; user_id?: string };
       try {
         data = JSON.parse(raw.toString());
       } catch {
@@ -190,6 +190,16 @@ const app = new BedrockAgentCoreApp({
 
       const request = data.request;
       const msgSessionId = data.session_id;
+      // Prefer the verified caller id from the presigned connection (custom
+      // header), but fall back to the client-supplied user_id — the platform
+      // doesn't always surface the connection's custom header to a WebSocket
+      // runtime, so getUserId(context) can be undefined. This mirrors the HTTP
+      // invocation path (req.user_id ?? getUserId(context)). The connection is
+      // already authenticated by the presigned URL and session ids are
+      // unguessable UUIDs, so the residual exposure — a caller who knows both
+      // another user's session id AND their sub — matches what the HTTP path
+      // already accepts.
+      const effectiveUserId = userId ?? data.user_id;
 
       if (!request) {
         send({ type: 'error', error: 'Missing required field: request' });
@@ -205,7 +215,7 @@ const app = new BedrockAgentCoreApp({
         // loading that session's stored config, tools, and MCP servers and
         // enforcing ownership. Disconnect the previous session's MCP clients.
         if (agent === null || msgSessionId !== sessionId) {
-          const built = await buildAgentForSession(msgSessionId, userId);
+          const built = await buildAgentForSession(msgSessionId, effectiveUserId);
           if (!built) {
             send({ type: 'error', error: 'Session does not belong to this user' });
             return;
@@ -216,7 +226,7 @@ const app = new BedrockAgentCoreApp({
           mcpClients = built.mcpClients;
         }
 
-        await handleUserMessage(agent, { request, sessionId, userId, send });
+        await handleUserMessage(agent, { request, sessionId, userId: effectiveUserId, send });
       } catch (err) {
         context.log.error({ err }, 'Error handling message');
         send({


### PR DESCRIPTION
## The bug

Every WebSocket chat message comes back `Session does not belong to this user`.

The runtime's WS handler derives the caller identity only from `getUserId(context)` — the presign's custom `X-Amzn-Bedrock-AgentCore-Runtime-Custom-User-Id`. But the AgentCore runtime logs confirm that on a WebSocket connection **`userId` is `undefined`**: the platform surfaces the presign's first-class `Session-Id` param as `context.sessionId`, but does **not** surface the custom `User-Id` param to the runtime. So `config.userId (the owner) !== undefined` → the ownership check rejects every session that has an owner.

## The fix

The **HTTP** invocation path already handles this with `req.user_id ?? getUserId(context)`. The WebSocket path never got the same fallback. Add it:

```ts
const effectiveUserId = userId ?? data.user_id;
```

used for both the ownership check and memory scoping. The chat client already sends `user_id` in each message.

## Security posture

The connection is already authenticated by the presigned URL (the Core API verified the caller's Cognito token before signing), and session ids are unguessable UUIDs. So the residual exposure — a caller who knows **both** another user's session id and their `sub` — is exactly what the HTTP path already accepts. This brings WebSocket to parity; it isn't a new class of risk.

A stricter long-term option (not needed to unblock) is to make the platform surface the verified custom user id to the WebSocket runtime, or to enforce session ownership in the presign (`/agent/connect`) where the verified identity is available.

## Impact

Unblocks the Booked "Ask your blog" chat end to end — messages now reach the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
