### PR TITLE
Version the AgentCore runtime artifact key so deploys roll the runtime

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,7 +75,12 @@ jobs:
           # (AgentCoreRuntime pulls it from the assets bucket).
           node scripts/package-agent.mjs
           ( cd agent-runtime/.artifact && zip -qr ../agent.zip . )
-          aws s3 cp agent-runtime/agent.zip s3://readysetcloud/agent/agent.zip
+          # Version the artifact key by commit SHA so the AgentCoreRuntime
+          # resource's Prefix changes each deploy. With a static key, CloudFormation
+          # sees no diff and never rolls the runtime, so it keeps serving the old
+          # bundle even after the new one is uploaded.
+          AGENT_ARTIFACT_KEY="agent/agent-${GITHUB_SHA}.zip"
+          aws s3 cp agent-runtime/agent.zip "s3://readysetcloud/${AGENT_ARTIFACT_KEY}"
 
           sam --info
           sam build --parallel
@@ -85,7 +90,7 @@ jobs:
           --resolve-s3 \
           --no-fail-on-empty-changeset \
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
-          --parameter-overrides UpdateGitHubSourceCode=true DefaultCacheName=readysetcloud BucketName=readysetcloud AmplifyAppId=${{ secrets.PROD_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }} RootDomainName=readysetcloud.io HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
+          --parameter-overrides UpdateGitHubSourceCode=true DefaultCacheName=readysetcloud BucketName=readysetcloud AgentArtifactKey=${AGENT_ARTIFACT_KEY} AmplifyAppId=${{ secrets.PROD_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }} RootDomainName=readysetcloud.io HostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
 
   publish-ui:
     name: Publish UI package

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -76,7 +76,11 @@ jobs:
           # artifact before deploy (AgentCoreRuntime pulls it from the bucket).
           node scripts/package-agent.mjs
           ( cd agent-runtime/.artifact && zip -qr ../agent.zip . )
-          aws s3 cp agent-runtime/agent.zip s3://readysetcloud-stage/agent/agent.zip
+          # Version the artifact key by commit SHA so the AgentCoreRuntime
+          # resource's Prefix changes each deploy (a static key means CloudFormation
+          # never rolls the runtime, leaving it on the old bundle).
+          AGENT_ARTIFACT_KEY="agent/agent-${GITHUB_SHA}.zip"
+          aws s3 cp agent-runtime/agent.zip "s3://readysetcloud-stage/${AGENT_ARTIFACT_KEY}"
 
           sam --info
           sam build --parallel
@@ -86,7 +90,7 @@ jobs:
           --resolve-s3 \
           --no-fail-on-empty-changeset \
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
-          --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
+          --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AgentArtifactKey=${AGENT_ARTIFACT_KEY} AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
 
   publish-ui:
     name: Publish UI hosted assets (stage)
@@ -160,7 +164,11 @@ jobs:
           # artifact before deploy (AgentCoreRuntime pulls it from the bucket).
           node scripts/package-agent.mjs
           ( cd agent-runtime/.artifact && zip -qr ../agent.zip . )
-          aws s3 cp agent-runtime/agent.zip s3://readysetcloud-stage/agent/agent.zip
+          # Version the artifact key by commit SHA so the AgentCoreRuntime
+          # resource's Prefix changes each deploy (a static key means CloudFormation
+          # never rolls the runtime, leaving it on the old bundle).
+          AGENT_ARTIFACT_KEY="agent/agent-${GITHUB_SHA}.zip"
+          aws s3 cp agent-runtime/agent.zip "s3://readysetcloud-stage/${AGENT_ARTIFACT_KEY}"
 
           sam --info
           sam build --parallel
@@ -170,7 +178,7 @@ jobs:
           --resolve-s3 \
           --no-fail-on-empty-changeset \
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
-          --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
+          --parameter-overrides UpdateGitHubSourceCode=false DefaultCacheName=readysetcloud-stage BucketName=readysetcloud-stage AgentArtifactKey=${AGENT_ARTIFACT_KEY} AmplifyAppId=${{ secrets.STAGE_AMPLIFY_APP_ID }} SendgridApiKey=${{ secrets.SENDGRID }} GitHubPAT=${{ secrets.GITHUB }} OpenAIApiKey=${{ secrets.OPENAI }} MomentoApiKey=${{ secrets.MOMENTO }}
 
   auto-merge-dependabot-update:
     name: Auto Merge Dependabot Update

--- a/template.yaml
+++ b/template.yaml
@@ -55,7 +55,15 @@ Parameters:
   AgentArtifactKey:
     Type: String
     Default: agent/agent.zip
-    Description: S3 key (in the assets BucketName) of the packaged NODE_22 agent runtime artifact.
+    Description: >
+      S3 key (in the assets BucketName) of the packaged NODE_22 agent runtime
+      artifact. MUST be unique per artifact build — the deploy passes a
+      commit-SHA-versioned key. If this is left at a STATIC value, the
+      AgentCoreRuntime resource's Prefix never changes, CloudFormation sees no
+      diff, and the runtime keeps serving the OLD bundle even after a new one is
+      uploaded (agent-runtime code changes silently never take effect). Do not
+      "simplify" the deploy back to a fixed key. The static default here is only a
+      last-resort fallback for a first-ever create.
   McpAllowedHosts:
     Type: String
     Default: ''
@@ -771,6 +779,10 @@ Resources:
           Code:
             S3:
               Bucket: !Ref BucketName
+              # Prefix MUST change when the artifact changes (deploy passes a
+              # commit-SHA-versioned AgentArtifactKey). A static Prefix means CFN
+              # never rolls this runtime and it serves a stale bundle. See the
+              # AgentArtifactKey parameter.
               Prefix: !Ref AgentArtifactKey
           EntryPoint:
             # The esbuild bundle's entry (see agent-runtime/build.mjs). Verify this


### PR DESCRIPTION
## The bug (why runtime fixes "deploy" but don't take effect)

The deploy packages the agent-runtime bundle and uploads it to a **static** S3 key (`agent/agent.zip`), and `AgentArtifactKey` defaults to that same static value. The `AgentCoreRuntime` resource references it as `S3.Prefix: !Ref AgentArtifactKey`.

Because that Prefix never changes, **CloudFormation sees no diff on the runtime resource and never rolls it** — so AgentCore keeps serving the *old* bundle even though a fresh `agent.zip` was just uploaded. This is why the WebSocket `userId` fix (#203) merged and "deployed" but the runtime still ran the old code (its `WebSocket connected` log still had no `userId`, and messages still 401'd with "Session does not belong to this user").

## The fix

Upload to a commit-SHA-versioned key (`agent/agent-${GITHUB_SHA}.zip`) and pass it as the `AgentArtifactKey` override — in the prod block and both staging blocks. Now every deploy changes the Prefix, so CloudFormation rolls the runtime to the new artifact. Runtime code changes actually ship.

(Trade-off: the runtime re-provisions on every rsc-core deploy, not just agent changes. That's the safe default — it guarantees the running runtime always matches deployed code. Can be narrowed to a content hash later if the churn matters.)

## Impact

Merging this re-deploys and **rolls the runtime to the latest code — including #203's WebSocket userId fix** — so the Booked chat's messages finally reach the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
