### PR TITLE
Ship @aws-sdk/client-eventbridge in the AgentCore runtime artifact

### DIFF
--- a/scripts/package-agent.mjs
+++ b/scripts/package-agent.mjs
@@ -27,6 +27,13 @@ const RUNTIME_DEPS = {
   '@aws-sdk/lib-dynamodb': '^3.0.0',
   '@aws-sdk/client-s3vectors': '^3.0.0',
   '@aws-sdk/client-bedrock-runtime': '^3.0.0',
+  // @readysetcloud/agent's root barrel re-exports requestSession (session
+  // creation via EventBridge), which instantiates an EventBridgeClient at module
+  // scope. The bundle inlines @readysetcloud/agent, and build.mjs marks
+  // @aws-sdk/* external, so this client must ship in the artifact even though the
+  // runtime never calls requestSession — otherwise the runtime crashes on boot
+  // with ERR_MODULE_NOT_FOUND and every WebSocket handshake fails.
+  '@aws-sdk/client-eventbridge': '^3.0.0',
   zod: '^4.1.12',
 };
 


### PR DESCRIPTION
## Problem

The AgentCore runtime crashes on boot with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@aws-sdk/client-eventbridge' imported from /var/task/index.js
```

so it never starts serving, and **every WebSocket handshake to the runtime fails** (the browser sees the `wss://bedrock-agentcore…` connection fail to open).

## Root cause

- The runtime bundle inlines `@readysetcloud/agent`. Its **root barrel** now re-exports `requestSession` (the EventBridge-based session-create helper added in the 0.2.0 event-handoff work).
- `agent/src/aws/events.ts` instantiates an `EventBridgeClient` at **module scope** — a side effect, so esbuild can't tree-shake the module out even though the runtime never calls `requestSession`.
- `agent-runtime/build.mjs` marks `@aws-sdk/*` **external**, and the artifact's `node_modules` is built solely from `RUNTIME_DEPS` in `scripts/package-agent.mjs`. That list had every other SDK client but not `client-eventbridge` → the import resolves to nothing at runtime → crash.

This only surfaced now because rsc-core #204 (commit-SHA-versioned artifact key) was the first deploy to actually **roll** the runtime onto the post-0.2.0 bundle. The previously-serving bundle predated the eventbridge dependency.

## Fix

Add `@aws-sdk/client-eventbridge` to `RUNTIME_DEPS` so it ships in the artifact's `node_modules`, exactly like the other externalized SDK clients.

## Verification

- Fix is confined to the artifact dependency manifest.
- After merge + prod deploy (which now rolls the runtime via the versioned key), the runtime should log a clean `Server listening…` and WebSocket connections should establish. Will confirm live once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)