### PR TITLE
Front the AgentCore runtime socket with a CloudFront reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,27 @@ memory model, so any app can drop in a chat surface with
 2. **Presign.** The browser calls `POST /agent/connect` with that `sessionId`.
    `WebSocketConnectFunction` returns a SigV4-presigned `wss://` URL to the
    AgentCore Runtime, carrying the verified Cognito `sub` as a custom header — so
-   the agent's identity is the real caller, never a client value.
-3. **Stream.** The browser opens the presigned socket directly to the runtime.
-   The runtime **loads the session's config by `sessionId`, enforces that the
-   verified caller is the session's owner** (a leaked/guessed id can't resume
-   someone else's conversation; missing config falls back to defaults), builds
-   the assistant, and streams `stream_event` → `complete` frames over the wire
-   protocol `@readysetcloud/ui/chat` speaks.
+   the agent's identity is the real caller, never a client value. When a custom
+   domain is deployed, that URL points at the `chat.${RootDomainName}` CloudFront
+   proxy (see below) instead of the raw `bedrock-agentcore` host, so the AWS
+   account id never appears in the client-visible URL.
+3. **Stream.** The browser opens the presigned socket to the runtime (directly,
+   or through the proxy). The runtime **loads the session's config by
+   `sessionId`, enforces that the verified caller is the session's owner** (a
+   leaked/guessed id can't resume someone else's conversation; missing config
+   falls back to defaults), builds the assistant, and streams `stream_event` →
+   `complete` frames over the wire protocol `@readysetcloud/ui/chat` speaks.
+
+   > **Reverse proxy (custom-domain deploys).** The presigned URL would
+   > otherwise expose the account id — it sits in the runtime ARN in the path
+   > (`…/runtimes/arn:aws:bedrock-agentcore:<region>:<account>:runtime/…/ws`).
+   > `ChatProxyDistribution` fronts the runtime at `wss://chat.${RootDomainName}`:
+   > the browser connects to `/ws?<sigv4 query>`, CloudFront prepends
+   > `/runtimes/<arn>` (OriginPath) and restores the `bedrock-agentcore` Host
+   > (the `AllViewerExceptHostHeader` managed policy), so the **same** signature
+   > validates. The Lambda signs the real host + path; only the URL it returns is
+   > rewritten. Region survives inside `X-Amz-Credential` (unavoidable for any
+   > presigned URL) but is not sensitive — the account id is gone.
 4. **Remember.** Each turn is written to `AgentChatTable` (`pk=MEMORY#{userId}` /
    `SESSION#{sessionId}`, TTL `expiresAt`). A stream filter on `entity=Turn`
    drives `VectorizeTurnFunction`, which embeds turns (Titan v2 @ 1024) into the

--- a/functions/websocket-connect.mjs
+++ b/functions/websocket-connect.mjs
@@ -12,6 +12,10 @@ import { randomUUID } from 'crypto';
  *      authorizer). The verified `sub` is the identity — never the body.
  *   2. This function signs a wss:// URL with the Lambda execution role (SigV4).
  *   3. The browser connects with the presigned URL (no custom headers needed).
+ *      When PROXY_WSS_HOST is set, that URL points at the CloudFront reverse
+ *      proxy (chat.<domain>) rather than the raw bedrock-agentcore host, so the
+ *      account id in the runtime ARN never reaches the client. See the wsUrl
+ *      construction below and ChatProxyDistribution in template.yaml.
  *   4. The verified user id rides along as a Custom-* query param, surfaced to
  *      the agent as the x-amzn-bedrock-agentcore-runtime-custom-user-id header,
  *      so memory recall is scoped to the real caller.
@@ -31,13 +35,10 @@ const escapeUri = (value) =>
   );
 
 /**
- * Formats a signed HttpRequest into a URL string. SignatureV4.presign() stores
- * raw (unencoded) query values, so we encode keys and values here.
+ * Builds the query string from a signed HttpRequest. SignatureV4.presign()
+ * stores raw (unencoded) query values, so we encode keys and values here.
  */
-const formatSignedUrl = (request) => {
-  const { protocol, hostname, path, query } = request;
-  const proto = protocol?.endsWith(':') ? protocol : `${protocol}:`;
-
+const buildQueryString = (query) => {
   const parts = [];
   for (const [key, value] of Object.entries(query ?? {})) {
     const encodedKey = escapeUri(key);
@@ -49,9 +50,7 @@ const formatSignedUrl = (request) => {
       parts.push(encodedKey);
     }
   }
-
-  const queryString = parts.join('&');
-  return `${proto}//${hostname}${path}${queryString ? `?${queryString}` : ''}`;
+  return parts.join('&');
 };
 
 export const handler = async (event) => {
@@ -108,7 +107,27 @@ export const handler = async (event) => {
       signingDate: new Date()
     });
 
-    const wsUrl = formatSignedUrl(signedRequest).replace('https://', 'wss://');
+    const queryString = buildQueryString(signedRequest.query);
+
+    // The signature is bound to the bedrock-agentcore host + /runtimes/<arn>/ws
+    // path signed above; the query string (X-Amz-Signature and friends) is what
+    // authorizes the connection and never changes below.
+    //
+    // With PROXY_WSS_HOST set, the browser connects through the CloudFront
+    // reverse proxy at chat.<domain> instead of the raw AgentCore host. The proxy
+    // is configured (template.yaml, ChatProxyDistribution) to prepend
+    // /runtimes/<arn> via OriginPath and restore the bedrock-agentcore Host
+    // header, so this same signature still validates at the runtime — while the
+    // browser only ever sees "/ws" and the account id in the ARN stays hidden.
+    // Region is unavoidably present inside X-Amz-Credential (a property of every
+    // presigned URL), but it is not sensitive.
+    //
+    // Without PROXY_WSS_HOST (no custom domain deployed), the browser connects
+    // straight to the runtime with the full signed host and path.
+    const proxyHost = process.env.PROXY_WSS_HOST;
+    const wsUrl = proxyHost
+      ? `wss://${proxyHost}/ws?${queryString}`
+      : `wss://${signedRequest.hostname}${signedRequest.path}?${queryString}`;
 
     return response(200, { wsUrl, sessionId, userId, expiresIn: EXPIRES_IN_SECONDS });
   } catch (error) {

--- a/template.yaml
+++ b/template.yaml
@@ -682,6 +682,12 @@ Resources:
       Environment:
         Variables:
           AGENT_RUNTIME_ARN: !Sub 'arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:runtime/${AgentCoreRuntime}'
+          # When a custom domain is deployed, hand the browser a wss:// URL that
+          # points at the CloudFront reverse proxy (ChatProxyDistribution) instead
+          # of the raw bedrock-agentcore host, so the account id in the runtime ARN
+          # never appears in the client-visible URL. Unset (no custom domain) =>
+          # the Lambda returns the direct signed URL.
+          PROXY_WSS_HOST: !If [DeployCustomDomainSupport, !Sub 'chat.${RootDomainName}', !Ref 'AWS::NoValue']
       Policies:
         - AWSLambdaBasicExecutionRole
         - Version: 2012-10-17
@@ -1028,6 +1034,80 @@ Resources:
       RestApiId: !Ref CoreRestApi
       Stage: Prod
       BasePath: core
+
+  # --- AgentCore runtime WebSocket reverse proxy ---------------------------
+  # Without this, the browser's presigned wss:// URL points straight at
+  #   bedrock-agentcore.<region>.amazonaws.com/runtimes/<runtimeArn>/ws
+  # which exposes the AWS account id (embedded in the ARN) to every client. This
+  # CloudFront distribution fronts the runtime under chat.${RootDomainName}: the
+  # browser connects to wss://chat.${RootDomainName}/ws?<sigv4 query>, CloudFront
+  # prepends /runtimes/<arn> (OriginPath) and sets the Host back to the
+  # bedrock-agentcore origin (the AllViewerExceptHostHeader managed policy), so
+  # the SigV4 signature websocket-connect produced still validates. Only the URL
+  # handed to the browser is rewritten; the Lambda signs the real host + path.
+  # Region still rides inside X-Amz-Credential (unavoidable for any presigned
+  # URL), but it is not sensitive; the account id no longer appears at all.
+  #
+  # The ACM cert MUST be in us-east-1 for CloudFront — this stack deploys there,
+  # so an in-stack certificate works (same pattern as AuthCertificate).
+  ChatCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: DeployCustomDomainSupport
+    Properties:
+      DomainName: !Sub chat.${RootDomainName}
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub chat.${RootDomainName}
+          HostedZoneId: !Ref HostedZoneId
+
+  ChatProxyDistribution:
+    Type: AWS::CloudFront::Distribution
+    Condition: DeployCustomDomainSupport
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub 'AgentCore runtime WebSocket proxy (${RootDomainName})'
+        Aliases:
+          - !Sub chat.${RootDomainName}
+        ViewerCertificate:
+          AcmCertificateArn: !Ref ChatCertificate
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+        Origins:
+          - Id: agentcore-runtime
+            DomainName: !Sub bedrock-agentcore.${AWS::Region}.amazonaws.com
+            # Prepended to every request path: the browser sends "/ws" and the
+            # origin receives "/runtimes/<arn>/ws". This is where the account-id-
+            # bearing ARN is kept off the wire the client sees.
+            OriginPath: !Sub '/runtimes/arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:runtime/${AgentCoreRuntime}'
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+        DefaultCacheBehavior:
+          TargetOriginId: agentcore-runtime
+          ViewerProtocolPolicy: https-only
+          AllowedMethods: [GET, HEAD]
+          CachedMethods: [GET, HEAD]
+          # Managed CachingDisabled — a streaming socket handshake is never cached.
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          # Managed AllViewerExceptHostHeader — forwards every viewer query param
+          # (the SigV4 signature) while letting CloudFront set Host to the origin
+          # (bedrock-agentcore), which is exactly the Host the presign signed.
+          OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
+
+  ChatProxyDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: DeployCustomDomainSupport
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub chat.${RootDomainName}
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt ChatProxyDistribution.DomainName
+        # Fixed CloudFront hosted-zone id — identical for every distribution.
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
 
   CognitoUserPoolClient:
     Type: AWS::Cognito::UserPoolClient


### PR DESCRIPTION
The browser's presigned wss:// URL pointed straight at
bedrock-agentcore.<region>.amazonaws.com/runtimes/<runtimeArn>/ws, so the
AWS account id (embedded in the runtime ARN) was exposed to every client.

Add a CloudFront distribution (chat.<RootDomainName>) that fronts the
runtime: the browser connects to /ws?<sigv4 query>, CloudFront prepends
/runtimes/<arn> via OriginPath and restores the bedrock-agentcore Host
(AllViewerExceptHostHeader managed policy), so the same SigV4 signature
still validates. websocket-connect signs the real host + path and only
rewrites the URL it hands back when PROXY_WSS_HOST is set. Region still
rides inside X-Amz-Credential (inherent to any presigned URL) but is not
sensitive; the account id no longer appears at all.

Gated on the existing DeployCustomDomainSupport condition; the ACM cert is
in-stack (us-east-1) alongside the CloudFront distribution and Route53
alias record.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbaET9FikMk5bkEDCvkFPJ