### PR TITLE
Adopt AgentCore inbound JWT auth for the agent WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,30 +151,36 @@ memory model, so any app can drop in a chat surface with
    runtime forwards verbatim to that MCP server, propagating the verified user's
    identity to a per-tenant tool — see the [package
    README](agent/README.md#mcp-servers-external-tools).
-2. **Presign.** The browser calls `POST /agent/connect` with that `sessionId`.
-   `WebSocketConnectFunction` returns a SigV4-presigned `wss://` URL to the
-   AgentCore Runtime, carrying the verified Cognito `sub` as a custom header — so
-   the agent's identity is the real caller, never a client value. When a custom
-   domain is deployed, that URL points at the `chat.${RootDomainName}` CloudFront
-   proxy (see below) instead of the raw `bedrock-agentcore` host, so the AWS
-   account id never appears in the client-visible URL.
-3. **Stream.** The browser opens the presigned socket to the runtime (directly,
-   or through the proxy). The runtime **loads the session's config by
-   `sessionId`, enforces that the verified caller is the session's owner** (a
-   leaked/guessed id can't resume someone else's conversation; missing config
-   falls back to defaults), builds the assistant, and streams `stream_event` →
-   `complete` frames over the wire protocol `@readysetcloud/ui/chat` speaks.
+2. **Get the URL.** The browser calls `POST /agent/connect` with that
+   `sessionId`. `WebSocketConnectFunction` returns the `wss://` URL to the
+   AgentCore Runtime (with the runtime session id as a query param) — no signing.
+   When a custom domain is deployed, that URL points at the
+   `chat.${RootDomainName}` CloudFront proxy (see below) instead of the raw
+   `bedrock-agentcore` host, so the AWS account id never appears in the
+   client-visible URL.
+3. **Stream.** The browser opens the socket (directly or through the proxy),
+   presenting its **Cognito ID token as an OAuth bearer** in the
+   `Sec-WebSocket-Protocol` handshake header
+   (`base64UrlBearerAuthorization.<base64url(jwt)>`). The runtime's **inbound JWT
+   authorizer** (`AuthorizerConfiguration`, validating the shared user pool)
+   verifies the token before the request lands, then forwards it as the
+   `Authorization` header; the runtime reads the verified `sub` from it — the
+   agent's identity is the real caller, never a client value. The runtime then
+   **loads the session's config by `sessionId`, enforces that the verified caller
+   is the session's owner** (a leaked/guessed id can't resume someone else's
+   conversation; missing config falls back to defaults), builds the assistant,
+   and streams `stream_event` → `complete` frames over the wire protocol
+   `@readysetcloud/ui/chat` speaks.
 
-   > **Reverse proxy (custom-domain deploys).** The presigned URL would
-   > otherwise expose the account id — it sits in the runtime ARN in the path
+   > **Reverse proxy (custom-domain deploys).** The URL would otherwise expose
+   > the account id — it sits in the runtime ARN in the path
    > (`…/runtimes/arn:aws:bedrock-agentcore:<region>:<account>:runtime/…/ws`).
    > `ChatProxyDistribution` fronts the runtime at `wss://chat.${RootDomainName}`:
-   > the browser connects to `/ws?<sigv4 query>`, CloudFront prepends
+   > the browser connects to `/ws?<session-id query>`, CloudFront prepends
    > `/runtimes/<arn>` (OriginPath) and restores the `bedrock-agentcore` Host
-   > (the `AllViewerExceptHostHeader` managed policy), so the **same** signature
-   > validates. The Lambda signs the real host + path; only the URL it returns is
-   > rewritten. Region survives inside `X-Amz-Credential` (unavoidable for any
-   > presigned URL) but is not sensitive — the account id is gone.
+   > (the `AllViewerExceptHostHeader` managed policy, which also forwards the
+   > `Sec-WebSocket-Protocol` bearer). Only the URL is rewritten; the bearer token
+   > still authorizes the connection at the runtime. The account id is gone.
 4. **Remember.** Each turn is written to `AgentChatTable` (`pk=MEMORY#{userId}` /
    `SESSION#{sessionId}`, TTL `expiresAt`). A stream filter on `entity=Turn`
    drives `VectorizeTurnFunction`, which embeds turns (Titan v2 @ 1024) into the
@@ -184,7 +190,7 @@ memory model, so any app can drop in a chat surface with
 | Method & path | Auth | Purpose |
 | --- | --- | --- |
 | `POST /agent/sessions` | Cognito JWT | Create a session (prompt/model/params); returns `{ sessionId }` |
-| `POST /agent/connect` | Cognito JWT | Presigned `wss://` URL to the runtime for a `sessionId` |
+| `POST /agent/connect` | Cognito JWT | `wss://` URL to the runtime for a `sessionId` (auth is the bearer on the socket, not a signed URL) |
 
 ### Pieces
 
@@ -192,7 +198,7 @@ memory model, so any app can drop in a chat surface with
 | --- | --- |
 | Portable agent core (assistant, memory, streaming) | `@readysetcloud/agent` → [`agent/`](agent/) |
 | AgentCore Runtime artifact (NODE_22 WebSocket host) | [`agent-runtime/`](agent-runtime/) |
-| Session, presign + vectorizer Lambdas | [`functions/create-session.mjs`](functions/create-session.mjs), [`functions/websocket-connect.mjs`](functions/websocket-connect.mjs), [`functions/vectorize-turn.mjs`](functions/vectorize-turn.mjs) |
+| Session, connect + vectorizer Lambdas | [`functions/create-session.mjs`](functions/create-session.mjs), [`functions/websocket-connect.mjs`](functions/websocket-connect.mjs), [`functions/vectorize-turn.mjs`](functions/vectorize-turn.mjs) |
 | Infra (table, S3 Vectors, runtime, IAM, `POST /agent/sessions` + `/agent/connect`) | [`template.yaml`](template.yaml) |
 | Artifact packaging (esbuild bundle + arm64 node_modules) | [`scripts/package-agent.mjs`](scripts/package-agent.mjs) |
 | React chat surface | `@readysetcloud/ui/chat` → [`ui/src/chat/`](ui/src/chat/) |
@@ -219,12 +225,23 @@ const authed = async (path, body) =>
     body: JSON.stringify(body)
   })).json();
 
+// base64url without padding — how AgentCore expects the bearer in the subprotocol.
+const b64url = (s) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
 // 1. Create a session once (optionally set prompt/model), keep the id in state.
 const { sessionId } = await authed('/agent/sessions', { systemPrompt, modelId });
 
-// 2. Presign per (re)connect. The verified sub becomes the agent's userId
-//    server-side — never pass it from the client.
-const getConnectionUrl = async (sid?: string) => (await authed('/agent/connect', { sessionId: sid })).wsUrl;
+// 2. Per (re)connect, return the URL + the Cognito ID token as an OAuth bearer
+//    subprotocol. The runtime's inbound JWT authorizer validates it and reads the
+//    verified sub server-side — never pass a user id from the client.
+const getConnectionUrl = async (sid?: string) => {
+  const { wsUrl } = await authed('/agent/connect', { sessionId: sid });
+  const token = await getToken();
+  return {
+    url: wsUrl,
+    protocols: [`base64UrlBearerAuthorization.${b64url(token)}`, 'base64UrlBearerAuthorization'],
+  };
+};
 
 // 3. Render.
 <Chat sessionId={sessionId} userId={user.sub} getConnectionUrl={getConnectionUrl} title="Assistant" />;
@@ -240,11 +257,22 @@ row.
 - **`AWS::BedrockAgentCore::Runtime` `EntryPoint: index.js`** — cfn-lint's spec
   doesn't yet know the Node runtimes (`E3030 NODE_22`) and there's no first-party
   TS WebSocket tutorial, so confirm the literal against a real deploy.
+- **Inbound JWT authorizer** — confirm the runtime's
+  `AuthorizerConfiguration.CustomJWTAuthorizerConfiguration` accepts the browser's
+  Cognito **ID** token: `AllowedAudience` matches the token `aud` (the app client
+  id), and the `DiscoveryUrl` issuer matches the token `iss`. A rejected token
+  closes the socket (codes `4401`/`1008`, which the UI client surfaces).
+- **Bearer over WebSocket** — confirm AgentCore accepts the OAuth bearer in the
+  `Sec-WebSocket-Protocol` subprotocol (`base64UrlBearerAuthorization.<b64url>`)
+  with the runtime session id as a query param, and that the CloudFront proxy
+  forwards that subprotocol header. This mirrors the `bedrock-agentcore` SDK's own
+  browser helper (`RuntimeClient.connectShellOAuth`).
+- **Verified identity in the runtime** — confirm AgentCore forwards the validated
+  token as the `Authorization` header (the SDK filters headers to
+  `Authorization` + `Custom-*`), so `getUserId` decodes the `sub`. If it surfaces
+  identity differently, adjust `agent-runtime/src/index.ts`.
 - **End-to-end stream** — sign in → `POST /agent/connect` → open the socket →
   confirm `stream_event`→`complete`, multi-turn continuity (snapshots), and that
   `recall_memory` returns prior-session facts.
 - **arm64 packaging** — `scripts/package-agent.mjs` stages the zip; confirm it
   runs on the runtime (all deps are pure-JS today).
-- **Runtime-provided SDK** — `websocket-connect.mjs` treats `@aws-sdk/*`
-  (incl. `@aws-sdk/credential-provider-node`) as runtime-provided; confirm they
-  resolve on the Node 24 Lambda runtime.

--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -21,11 +21,47 @@ import type { Agent, McpServerConfig } from '@strands-agents/sdk';
 // Deployed to AgentCore Runtime as a NODE_22 arm64 CodeZip bundle (see
 // build.mjs + scripts/package-agent.mjs).
 
-// The presigned-URL Lambda passes the verified Cognito sub as this custom
+// Legacy fallback: a presign-style caller could pass the user id as a custom
 // header; AgentCore forwards Custom-* headers to the runtime (lower-cased).
 const CUSTOM_USER_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-custom-user-id';
 
+/**
+ * Decodes (does NOT verify) a JWT's `sub`. AgentCore's inbound JWT authorizer
+ * (AuthorizerConfiguration in template.yaml) has already validated the token's
+ * issuer, signature, and expiry against the shared Cognito pool before the
+ * request reaches this runtime — the runtime is behind that boundary and is only
+ * reachable through the AgentCore data plane, so it just reads the claim.
+ */
+function decodeJwtSub(token: string): string | undefined {
+  const payload = token.split('.')[1];
+  if (!payload) return undefined;
+  try {
+    const json = JSON.parse(
+      Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'),
+    ) as { sub?: unknown };
+    return typeof json.sub === 'string' ? json.sub : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The verified caller id. Primary source is the Cognito JWT that AgentCore
+ * Inbound Auth validated and forwards as the Authorization header — the runtime
+ * SDK filters incoming headers to Authorization + Custom-* (see
+ * bedrock-agentcore RequestContext). Falls back to the custom user-id header for
+ * the debug/HTTP path or a caller that still sets it explicitly.
+ */
 function getUserId(context: RequestContext): string | undefined {
+  const authKey = Object.keys(context.headers).find(
+    (h) => h.toLowerCase() === 'authorization',
+  );
+  const authHeader = authKey ? context.headers[authKey] : undefined;
+  if (authHeader) {
+    const sub = decodeJwtSub(authHeader.replace(/^Bearer\s+/i, ''));
+    if (sub) return sub;
+  }
+
   const direct = context.headers[CUSTOM_USER_ID_HEADER];
   if (direct) return direct;
   // Be tolerant of header-casing differences across AgentCore versions.
@@ -149,7 +185,8 @@ const app = new BedrockAgentCoreApp({
     requestSchema: invocationSchema,
     process: async (req, context) => {
       const sessionId = req.session_id ?? context.sessionId;
-      const userId = req.user_id ?? getUserId(context);
+      // Verified JWT identity wins; req.user_id is only a local/debug fallback.
+      const userId = getUserId(context) ?? req.user_id;
       const built = await buildAgentForSession(sessionId, userId);
       if (!built) {
         return {
@@ -190,16 +227,10 @@ const app = new BedrockAgentCoreApp({
 
       const request = data.request;
       const msgSessionId = data.session_id;
-      // Prefer the verified caller id from the presigned connection (custom
-      // header), but fall back to the client-supplied user_id — the platform
-      // doesn't always surface the connection's custom header to a WebSocket
-      // runtime, so getUserId(context) can be undefined. This mirrors the HTTP
-      // invocation path (req.user_id ?? getUserId(context)). The connection is
-      // already authenticated by the presigned URL and session ids are
-      // unguessable UUIDs, so the residual exposure — a caller who knows both
-      // another user's session id AND their sub — matches what the HTTP path
-      // already accepts.
-      const effectiveUserId = userId ?? data.user_id;
+      // Identity is the Cognito `sub` from the JWT that AgentCore Inbound Auth
+      // validated for this connection (captured once at connect time). The
+      // client-supplied data.user_id is ignored — it can no longer be trusted or
+      // needed now that the connection carries a verified bearer token.
 
       if (!request) {
         send({ type: 'error', error: 'Missing required field: request' });
@@ -215,7 +246,7 @@ const app = new BedrockAgentCoreApp({
         // loading that session's stored config, tools, and MCP servers and
         // enforcing ownership. Disconnect the previous session's MCP clients.
         if (agent === null || msgSessionId !== sessionId) {
-          const built = await buildAgentForSession(msgSessionId, effectiveUserId);
+          const built = await buildAgentForSession(msgSessionId, userId);
           if (!built) {
             send({ type: 'error', error: 'Session does not belong to this user' });
             return;
@@ -226,7 +257,7 @@ const app = new BedrockAgentCoreApp({
           mcpClients = built.mcpClients;
         }
 
-        await handleUserMessage(agent, { request, sessionId, userId: effectiveUserId, send });
+        await handleUserMessage(agent, { request, sessionId, userId, send });
       } catch (err) {
         context.log.error({ err }, 'Error handling message');
         send({

--- a/agent/README.md
+++ b/agent/README.md
@@ -63,7 +63,7 @@ const answer = await handleUserMessage(agent, {
 ```
 
 **Identity is the verified caller.** Pass `userId` from a trusted source (e.g. a
-Cognito `sub` on a presigned connection header), never a client-supplied value.
+Cognito `sub` from a verified inbound JWT), never a client-supplied value.
 `recall_memory` closes over that `userId`, so memory can't leak across users.
 
 ## Sessions (dynamic config)

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/agent",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1085.0",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Portable, framework-agnostic Node agent core for Ready, Set, Cloud: a Strands-TS assistant with DynamoDB-backed conversation history and semantic vector memory.",
   "author": "allenheltondev",
   "license": "MIT",

--- a/agent/src/memory/session-events.ts
+++ b/agent/src/memory/session-events.ts
@@ -44,7 +44,7 @@ export type RequestSessionOptions = CreateSessionOptions & {
 /**
  * Requests a session by emitting a "Create Agent Session" event, and returns the
  * `sessionId` immediately (generated here if not supplied) so the caller can
- * presign a connection right away. The owning stack's consumer creates the
+ * open a connection right away. The owning stack's consumer creates the
  * config row from the event. The caller needs only `events:PutEvents`.
  */
 export async function requestSession(options: RequestSessionOptions): Promise<{ sessionId: string }> {

--- a/functions/websocket-connect.mjs
+++ b/functions/websocket-connect.mjs
@@ -1,61 +1,44 @@
-import { SignatureV4 } from '@smithy/signature-v4';
-import { Sha256 } from '@aws-crypto/sha256-js';
-import { HttpRequest } from '@smithy/protocol-http';
-import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { randomUUID } from 'crypto';
 
 /**
- * Generates an AWS SigV4 presigned WebSocket URL so the browser can connect
- * directly to the AgentCore Runtime that hosts @readysetcloud/agent.
+ * Returns the wss:// URL the browser uses to open a streaming WebSocket to the
+ * AgentCore Runtime that hosts @readysetcloud/agent.
+ *
+ * Auth is AgentCore **Inbound Auth** (a Cognito JWT), not a SigV4 presigned URL:
  *
  *   1. The caller is authenticated by the shared Cognito pool (CoreApi JWT
- *      authorizer). The verified `sub` is the identity — never the body.
- *   2. This function signs a wss:// URL with the Lambda execution role (SigV4).
- *   3. The browser connects with the presigned URL (no custom headers needed).
- *      When PROXY_WSS_HOST is set, that URL points at the CloudFront reverse
- *      proxy (chat.<domain>) rather than the raw bedrock-agentcore host, so the
- *      account id in the runtime ARN never reaches the client. See the wsUrl
- *      construction below and ChatProxyDistribution in template.yaml.
- *   4. The verified user id rides along as a Custom-* query param, surfaced to
- *      the agent as the x-amzn-bedrock-agentcore-runtime-custom-user-id header,
- *      so memory recall is scoped to the real caller.
+ *      authorizer) — this endpoint just needs a signed-in user to hand back a
+ *      URL + session id.
+ *   2. The runtime is configured with a CustomJWTAuthorizerConfiguration
+ *      (template.yaml, AgentCoreRuntime) that validates the caller's Cognito ID
+ *      token against the shared user pool. The browser presents that token as an
+ *      OAuth bearer in the WebSocket handshake (Sec-WebSocket-Protocol), so the
+ *      URL itself carries no credential and needs no signing here.
+ *   3. AgentCore forwards the validated token to the runtime as the Authorization
+ *      header, from which the runtime reads the verified `sub` — identity is the
+ *      real caller, never a client-supplied value (see agent-runtime/src/index.ts).
  *
- * The SigV4 presign is hand-rolled (rather than pulling in the bedrock-agentcore
- * runtime SDK, which bundles Fastify) to keep this Lambda dependency-light.
- * Based on the official AWS bi-directional-streaming sample.
+ * The runtime session id rides as a query param (browsers can't set arbitrary
+ * WebSocket handshake headers). This mirrors the AgentCore SDK's own browser
+ * OAuth helper (bedrock-agentcore RuntimeClient.connectShellOAuth), which puts
+ * X-Amzn-Bedrock-AgentCore-Runtime-Session-Id in the query string and the bearer
+ * token in the subprotocol.
+ *
+ * When PROXY_WSS_HOST is set (custom-domain deploy), the URL points at the
+ * CloudFront reverse proxy (chat.<domain>) instead of the raw bedrock-agentcore
+ * host, so the account id in the runtime ARN never reaches the client. The proxy
+ * forwards the query params and the Sec-WebSocket-Protocol header unchanged and
+ * prepends /runtimes/<arn> (OriginPath) — see ChatProxyDistribution in
+ * template.yaml.
  */
 
-const EXPIRES_IN_SECONDS = 300;
-
-/** AWS-compatible URI escaping: encodeURIComponent plus !'()* per RFC 3986. */
-const escapeUri = (value) =>
-  encodeURIComponent(value).replace(
-    /[!'()*]/g,
-    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
-  );
-
-/**
- * Builds the query string from a signed HttpRequest. SignatureV4.presign()
- * stores raw (unencoded) query values, so we encode keys and values here.
- */
-const buildQueryString = (query) => {
-  const parts = [];
-  for (const [key, value] of Object.entries(query ?? {})) {
-    const encodedKey = escapeUri(key);
-    if (Array.isArray(value)) {
-      for (const v of value) parts.push(`${encodedKey}=${escapeUri(v)}`);
-    } else if (value != null) {
-      parts.push(`${encodedKey}=${escapeUri(value)}`);
-    } else {
-      parts.push(encodedKey);
-    }
-  }
-  return parts.join('&');
-};
+const SESSION_ID_PARAM = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
 
 export const handler = async (event) => {
   try {
-    const userId = event.requestContext?.authorizer?.claims?.sub ?? event.requestContext?.authorizer?.jwt?.claims?.sub;
+    const userId =
+      event.requestContext?.authorizer?.claims?.sub ??
+      event.requestContext?.authorizer?.jwt?.claims?.sub;
     if (!userId) {
       return response(401, { message: 'Unauthorized' });
     }
@@ -74,67 +57,24 @@ export const handler = async (event) => {
     }
     const sessionId = body.sessionId || randomUUID();
 
-    // wss://bedrock-agentcore.<region>.amazonaws.com/runtimes/<arn>/ws
-    // The ARN sits raw in the path; SigV4 handles canonical path encoding.
-    const wsHost = `bedrock-agentcore.${region}.amazonaws.com`;
-    const wsPath = `/runtimes/${runtimeArn}/ws`;
-
-    const query = {
-      qualifier: 'DEFAULT',
-      'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
-      // Pass the verified user id to the agent as a custom header query param.
-      'X-Amzn-Bedrock-AgentCore-Runtime-Custom-User-Id': userId
-    };
-
-    const request = new HttpRequest({
-      method: 'GET',
-      protocol: 'https:',
-      hostname: wsHost,
-      path: wsPath,
-      headers: { host: wsHost },
-      query
-    });
-
-    const signer = new SignatureV4({
-      service: 'bedrock-agentcore',
-      region,
-      credentials: defaultProvider(),
-      sha256: Sha256
-    });
-
-    const signedRequest = await signer.presign(request, {
-      expiresIn: EXPIRES_IN_SECONDS,
-      signingDate: new Date()
-    });
-
-    const queryString = buildQueryString(signedRequest.query);
-
-    // The signature is bound to the bedrock-agentcore host + /runtimes/<arn>/ws
-    // path signed above; the query string (X-Amz-Signature and friends) is what
-    // authorizes the connection and never changes below.
-    //
-    // With PROXY_WSS_HOST set, the browser connects through the CloudFront
-    // reverse proxy at chat.<domain> instead of the raw AgentCore host. The proxy
-    // is configured (template.yaml, ChatProxyDistribution) to prepend
-    // /runtimes/<arn> via OriginPath and restore the bedrock-agentcore Host
-    // header, so this same signature still validates at the runtime — while the
-    // browser only ever sees "/ws" and the account id in the ARN stays hidden.
-    // Region is unavoidably present inside X-Amz-Credential (a property of every
-    // presigned URL), but it is not sensitive.
-    //
-    // Without PROXY_WSS_HOST (no custom domain deployed), the browser connects
-    // straight to the runtime with the full signed host and path.
+    // Base path: proxy hides the account-id-bearing ARN behind chat.<domain>/ws;
+    // otherwise the browser connects straight to the runtime's /runtimes/<arn>/ws.
     const proxyHost = process.env.PROXY_WSS_HOST;
-    const wsUrl = proxyHost
-      ? `wss://${proxyHost}/ws?${queryString}`
-      : `wss://${signedRequest.hostname}${signedRequest.path}?${queryString}`;
+    const base = proxyHost
+      ? `wss://${proxyHost}/ws`
+      : `wss://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodeURIComponent(runtimeArn)}/ws`;
 
-    return response(200, { wsUrl, sessionId, userId, expiresIn: EXPIRES_IN_SECONDS });
+    const url = new URL(base);
+    url.searchParams.set('qualifier', 'DEFAULT');
+    url.searchParams.set(SESSION_ID_PARAM, sessionId);
+    const wsUrl = url.toString();
+
+    return response(200, { wsUrl, sessionId });
   } catch (error) {
-    console.error('Failed to generate presigned WebSocket URL', error);
+    console.error('Failed to build agent WebSocket URL', error);
     return response(500, {
       error: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to generate presigned WebSocket URL'
+      message: 'Failed to build agent WebSocket URL'
     });
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-lambda-powertools/parameters": "^2.34.0",
         "@gomomento/sdk": "^1.118.0",
         "@readysetcloud/agent": "file:agent",
         "@sendgrid/mail": "^8.1.6",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
         "octokit": "^5.0.5",
         "openai": "^6.46.0"
       },
@@ -37,11 +34,12 @@
     },
     "agent": {
       "name": "@readysetcloud/agent",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1085.0",
         "@aws-sdk/client-dynamodb": "^3.1085.0",
+        "@aws-sdk/client-eventbridge": "^3.1085.0",
         "@aws-sdk/client-s3vectors": "^3.1085.0",
         "@aws-sdk/lib-dynamodb": "^3.1085.0",
         "@strands-agents/sdk": "1.9.0",
@@ -61,31 +59,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
@@ -216,7 +189,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1086.0.tgz",
       "integrity": "sha512-oTukjn+4GvaO5M2NFS4SbEXAjLJQoxnpCVlDdAeNInLsQTFWFNvricZBLoOaKEjXYB2L21OtzC3E4nXYnf8qZA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
         "@aws-sdk/credential-provider-node": "^3.972.67",
@@ -237,7 +209,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1086.0.tgz",
       "integrity": "sha512-2Su89oU74tez+KQIEIx1JmBN2x4JziAxVL5kyjPEiNsDhMmglEj3JZjTneBRmPKsQJsyXGkpEgaZ7ELd5G26Jg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -280,7 +251,6 @@
       "integrity": "sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
         "@aws-sdk/core": "^3.975.1",
@@ -323,7 +293,6 @@
       "integrity": "sha512-FPyxcVdiiwvb+SS29oMrzPh2byOyKT8XRBynhII8z6iFcZ/ySdRnyDpZ+0yolzOyCFhH/X+lPidNxlc01ZOglQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
         "@aws-sdk/credential-provider-node": "^3.972.67",
@@ -748,7 +717,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.6.tgz",
       "integrity": "sha512-xLimZjA/ebA7jZn4NNkvLgj9WRl14rhidGND6oPt14s7ywe3I64g9X+WJpBraU5UR7loRq2K1tAXZj0FXkWLZg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -788,7 +756,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -801,7 +768,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -990,7 +956,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
       "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1022,6 +987,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1644,6 +1610,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1684,6 +1651,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1700,6 +1668,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1708,7 +1677,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1840,7 +1810,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2507,18 +2476,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
@@ -2527,19 +2484,6 @@
       "dependencies": {
         "@smithy/core": "^3.29.3",
         "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.8.tgz",
-      "integrity": "sha512-SyFyL/ajuzJ79W+BpseFFbSz8/Rwj+QGqUlayeZE0jS2aCcjzV5tJBcbHgfypvSHpe7s2JmUHZmfpICaxwEs5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.29.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2570,32 +2514,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2897,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2910,6 +2829,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2919,6 +2839,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2936,7 +2857,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2988,6 +2908,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -3005,6 +2926,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3020,7 +2942,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3115,6 +3038,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -3188,6 +3112,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3210,6 +3135,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3280,6 +3206,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3313,6 +3240,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3322,6 +3250,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -3331,6 +3260,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -3404,6 +3334,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3436,7 +3367,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3449,6 +3381,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3518,7 +3451,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3539,7 +3473,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3717,6 +3650,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3726,6 +3660,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -3738,6 +3673,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3801,6 +3737,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -3819,6 +3756,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3828,6 +3766,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3837,6 +3776,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3882,7 +3822,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3920,6 +3861,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -4015,6 +3957,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4024,6 +3967,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4128,8 +4072,7 @@
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
-      "license": "(BSD-3-Clause AND Apache-2.0)",
-      "peer": true
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -4197,6 +4140,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -4230,6 +4174,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4285,13 +4230,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4301,6 +4248,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -4341,7 +4289,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4354,6 +4303,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4376,7 +4326,8 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4734,6 +4685,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4743,6 +4695,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4833,6 +4786,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4842,6 +4796,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4851,6 +4806,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4905,6 +4861,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -4917,6 +4874,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4926,7 +4884,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
       "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
         "@smithy/hash-node": ">=4.3.0 <5",
@@ -5007,6 +4964,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5035,6 +4993,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -5060,7 +5019,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5073,6 +5031,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -5144,6 +5103,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -5176,6 +5136,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -5192,6 +5153,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       },
@@ -5205,6 +5167,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -5229,6 +5192,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5272,6 +5236,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -5287,7 +5252,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -5307,6 +5273,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -5333,6 +5300,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5342,6 +5310,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5358,6 +5327,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -5376,7 +5346,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -5454,6 +5425,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -5473,6 +5445,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -5489,6 +5462,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5507,6 +5481,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5550,6 +5525,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5645,6 +5621,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -5673,6 +5650,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -5691,6 +5669,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5700,6 +5679,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5749,6 +5729,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5781,6 +5762,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5791,7 +5773,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -6017,7 +5998,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6088,7 +6070,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6098,6 +6079,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -32,13 +32,10 @@
     "sharp": "^0.35.3"
   },
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-lambda-powertools/parameters": "^2.34.0",
     "@gomomento/sdk": "^1.118.0",
     "@readysetcloud/agent": "file:agent",
     "@sendgrid/mail": "^8.1.6",
-    "@smithy/protocol-http": "^5.0.0",
-    "@smithy/signature-v4": "^5.0.0",
     "octokit": "^5.0.5",
     "openai": "^6.46.0"
   }

--- a/template.yaml
+++ b/template.yaml
@@ -550,9 +550,10 @@ Resources:
   # AgentCore Runtime (NODE_22) that streams over a browser-direct WebSocket.
   #
   # Auth reuses the shared RSC Cognito pool: the browser calls
-  # POST /agent/connect on the CoreApi (Cognito authorizer), and
-  # WebSocketConnectFunction returns a SigV4-presigned wss:// URL carrying the
-  # verified sub as a custom header so memory recall is scoped to the caller.
+  # POST /agent/connect on the CoreApi (Cognito authorizer) for the wss:// URL,
+  # then opens the socket presenting its Cognito JWT as an OAuth bearer. The
+  # runtime's inbound JWT authorizer validates it and the runtime reads the
+  # verified sub, so memory recall is scoped to the real caller.
   #
   # Memory is owned here: conversation turns + Strands snapshots in AgentChatTable
   # (TTL expiresAt), semantic recall in an S3 Vectors index fed by the
@@ -686,18 +687,13 @@ Resources:
           # points at the CloudFront reverse proxy (ChatProxyDistribution) instead
           # of the raw bedrock-agentcore host, so the account id in the runtime ARN
           # never appears in the client-visible URL. Unset (no custom domain) =>
-          # the Lambda returns the direct signed URL.
+          # the Lambda returns the direct runtime URL.
           PROXY_WSS_HOST: !If [DeployCustomDomainSupport, !Sub 'chat.${RootDomainName}', !Ref 'AWS::NoValue']
+      # No bedrock-agentcore invoke permission needed: the connection is
+      # authorized by the caller's Cognito JWT (AgentCore Inbound Auth), not by
+      # this Lambda's role. It only builds a URL — see websocket-connect.mjs.
       Policies:
         - AWSLambdaBasicExecutionRole
-        - Version: 2012-10-17
-          Statement:
-            # The signed URL grants the browser a WebSocket stream to the runtime.
-            - Effect: Allow
-              Action:
-                - bedrock-agentcore:InvokeAgentRuntime
-                - bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream
-              Resource: !Sub 'arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:runtime/*'
       Events:
         PostAgentConnect:
           Type: Api
@@ -799,6 +795,21 @@ Resources:
           Runtime: NODE_22
       NetworkConfiguration:
         NetworkMode: PUBLIC
+      # Inbound Auth: AgentCore validates a Cognito JWT (issuer/signature/expiry)
+      # against the shared RSC user pool BEFORE the request reaches the runtime.
+      # The browser presents its ID token as an OAuth bearer on the WebSocket
+      # handshake (Sec-WebSocket-Protocol), so the hand-rolled SigV4 presign is
+      # gone — see functions/websocket-connect.mjs and WebSocketChatClient.ts.
+      #
+      # AllowedAudience (not AllowedClients): the UI issues Cognito **ID tokens**
+      # (getFreshIdToken), which carry `aud`=client-id and have no `client_id`
+      # claim. AgentCore matches the token's `aud` against this list. If you ever
+      # switch the UI to access tokens, use AllowedClients instead.
+      AuthorizerConfiguration:
+        CustomJWTAuthorizerConfiguration:
+          DiscoveryUrl: !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPool}/.well-known/openid-configuration'
+          AllowedAudience:
+            - !Ref CognitoUserPoolClient
       RoleArn: !GetAtt AgentCoreRole.Arn
       EnvironmentVariables:
         TABLE_NAME: !Ref AgentChatTable
@@ -1036,17 +1047,17 @@ Resources:
       BasePath: core
 
   # --- AgentCore runtime WebSocket reverse proxy ---------------------------
-  # Without this, the browser's presigned wss:// URL points straight at
+  # Without this, the browser's wss:// URL points straight at
   #   bedrock-agentcore.<region>.amazonaws.com/runtimes/<runtimeArn>/ws
   # which exposes the AWS account id (embedded in the ARN) to every client. This
   # CloudFront distribution fronts the runtime under chat.${RootDomainName}: the
-  # browser connects to wss://chat.${RootDomainName}/ws?<sigv4 query>, CloudFront
+  # browser connects to wss://chat.${RootDomainName}/ws?<session-id query> with
+  # the Cognito bearer in the Sec-WebSocket-Protocol subprotocol. CloudFront
   # prepends /runtimes/<arn> (OriginPath) and sets the Host back to the
-  # bedrock-agentcore origin (the AllViewerExceptHostHeader managed policy), so
-  # the SigV4 signature websocket-connect produced still validates. Only the URL
-  # handed to the browser is rewritten; the Lambda signs the real host + path.
-  # Region still rides inside X-Amz-Credential (unavoidable for any presigned
-  # URL), but it is not sensitive; the account id no longer appears at all.
+  # bedrock-agentcore origin (the AllViewerExceptHostHeader managed policy, which
+  # also forwards the Sec-WebSocket-Protocol header), so the runtime's inbound JWT
+  # authorizer validates the same bearer. Only the URL is rewritten; auth is the
+  # token, so nothing here is signed. The account id no longer appears at all.
   #
   # The ACM cert MUST be in us-east-1 for CloudFront — this stack deploys there,
   # so an in-stack certificate works (same pattern as AuthCertificate).
@@ -1092,8 +1103,9 @@ Resources:
           # Managed CachingDisabled — a streaming socket handshake is never cached.
           CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
           # Managed AllViewerExceptHostHeader — forwards every viewer query param
-          # (the SigV4 signature) while letting CloudFront set Host to the origin
-          # (bedrock-agentcore), which is exactly the Host the presign signed.
+          # (the runtime session id) and header (incl. Sec-WebSocket-Protocol,
+          # which carries the bearer) while letting CloudFront set Host to the
+          # bedrock-agentcore origin.
           OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
 
   ChatProxyDnsRecord:

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -212,7 +212,8 @@ Flow behaviors already handled: NEW_PASSWORD_REQUIRED challenge, unconfirmed-acc
 Streaming chat surface for the AgentCore agent (`@readysetcloud/agent`). On its
 own subpath (like `./auth`) so apps that don't render chat don't pull in
 `react-markdown` & friends. The app owns auth: it supplies a `getConnectionUrl`
-that returns a presigned `wss://` URL, and the components never import app auth.
+that returns the `wss://` URL plus the bearer subprotocol (AgentCore Inbound
+Auth), and the components never import app auth.
 
 ```tsx
 import { Chat } from '@readysetcloud/ui/chat';
@@ -226,12 +227,23 @@ const authed = async (path, body) =>
     body: JSON.stringify(body)
   })).json();
 
+// base64url without padding — how AgentCore expects the bearer in the subprotocol.
+const b64url = (s) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
 // 1. Create a session once (optionally set prompt/model), keep the id in state.
 const { sessionId } = await authed('/agent/sessions', { systemPrompt, modelId });
 
-// 2. Presign per (re)connect. The verified Cognito sub becomes the agent's
-//    userId server-side — never pass it from the client.
-const getConnectionUrl = async (sid?: string) => (await authed('/agent/connect', { sessionId: sid })).wsUrl;
+// 2. Per (re)connect, return the URL + the Cognito ID token as an OAuth bearer
+//    subprotocol. The runtime's inbound JWT authorizer validates it and the
+//    runtime reads the verified sub — never pass a user id from the client.
+const getConnectionUrl = async (sid?: string) => {
+  const { wsUrl } = await authed('/agent/connect', { sessionId: sid });
+  const token = await getToken();
+  return {
+    url: wsUrl,
+    protocols: [`base64UrlBearerAuthorization.${b64url(token)}`, 'base64UrlBearerAuthorization'],
+  };
+};
 
 <Chat sessionId={sessionId} userId={user.sub} getConnectionUrl={getConnectionUrl} title="Assistant" />;
 ```

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/ui",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "react-markdown": "^9.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
   "license": "MIT",
   "type": "module",

--- a/ui/src/chat/WebSocketChatClient.test.ts
+++ b/ui/src/chat/WebSocketChatClient.test.ts
@@ -13,7 +13,10 @@ class FakeWebSocket {
   onclose: ((e: { code: number }) => void) | null = null;
   sent: string[] = [];
 
-  constructor(public url: string) {
+  constructor(
+    public url: string,
+    public protocols?: string | string[],
+  ) {
     FakeWebSocket.instances.push(this);
   }
   open() {
@@ -39,7 +42,7 @@ beforeEach(() => {
 });
 
 describe('WebSocketChatClient', () => {
-  it('connects using the injected presigned URL and resolves on open', async () => {
+  it('connects using the injected URL and resolves on open', async () => {
     const getConnectionUrl = vi.fn().mockResolvedValue('wss://example/ws?sig=abc');
     const client = new WebSocketChatClient({ getConnectionUrl });
 
@@ -52,7 +55,24 @@ describe('WebSocketChatClient', () => {
 
     expect(getConnectionUrl).toHaveBeenCalledWith('sess-1');
     expect(socket.url).toBe('wss://example/ws?sig=abc');
+    expect(socket.protocols).toBeUndefined();
     expect(client.isConnected()).toBe(true);
+  });
+
+  it('passes bearer subprotocols through when getConnectionUrl returns them', async () => {
+    const protocols = ['base64UrlBearerAuthorization.abc123', 'base64UrlBearerAuthorization'];
+    const client = new WebSocketChatClient({
+      getConnectionUrl: async () => ({ url: 'wss://example/ws?sid=1', protocols }),
+    });
+
+    const connecting = client.connect('sess-1');
+    await Promise.resolve();
+    const socket = FakeWebSocket.instances[0]!;
+    socket.open();
+    await connecting;
+
+    expect(socket.url).toBe('wss://example/ws?sid=1');
+    expect(socket.protocols).toEqual(protocols);
   });
 
   it('sends a well-formed query frame', async () => {

--- a/ui/src/chat/WebSocketChatClient.ts
+++ b/ui/src/chat/WebSocketChatClient.ts
@@ -1,20 +1,33 @@
 import type { ServerMessage, ServerMessageListener } from './protocol';
 
 // Framework-agnostic WebSocket client for the AgentCore chat stream. The
-// caller injects a `getConnectionUrl` function that returns a presigned wss://
-// URL — so the client imports no app-specific auth/api and stays reusable
+// caller injects a `getConnectionUrl` function that returns the wss:// URL (and,
+// for AgentCore Inbound Auth, the WebSocket subprotocols that carry the bearer
+// token) — so the client imports no app-specific auth/api and stays reusable
 // across apps.
 
+/**
+ * What `getConnectionUrl` resolves to. Return a bare string for a URL that is
+ * self-authorizing (e.g. a legacy presigned URL), or `{ url, protocols }` to
+ * also pass WebSocket subprotocols — how a browser carries an OAuth bearer token
+ * to AgentCore, as `['base64UrlBearerAuthorization.<base64url(jwt)>',
+ * 'base64UrlBearerAuthorization']`. The app builds these from its own auth, so
+ * this package stays auth-agnostic.
+ */
+export type ChatConnectionTarget =
+  | string
+  | { url: string; protocols?: string | string[] };
+
 export interface WebSocketChatClientOptions {
-  /** Returns a presigned wss:// URL for the given session. */
-  getConnectionUrl: (sessionId?: string) => Promise<string>;
+  /** Returns the wss:// URL (and optional subprotocols) for the given session. */
+  getConnectionUrl: (sessionId?: string) => Promise<ChatConnectionTarget>;
 }
 
 type EventType = ServerMessage['type'] | 'open' | 'close';
 
 export class WebSocketChatClient {
   private ws: WebSocket | null = null;
-  private readonly getConnectionUrl: (sessionId?: string) => Promise<string>;
+  private readonly getConnectionUrl: (sessionId?: string) => Promise<ChatConnectionTarget>;
   private readonly listeners = new Map<EventType, Set<ServerMessageListener>>();
   private connected = false;
 
@@ -24,10 +37,14 @@ export class WebSocketChatClient {
 
   /** Opens a connection. Resolves once the socket is open. */
   async connect(sessionId?: string): Promise<void> {
-    const url = await this.getConnectionUrl(sessionId);
+    const target = await this.getConnectionUrl(sessionId);
+    const { url, protocols } =
+      typeof target === 'string' ? { url: target, protocols: undefined } : target;
 
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url);
+      // Pass subprotocols only when supplied — that's how the browser hands
+      // AgentCore the OAuth bearer token (Sec-WebSocket-Protocol).
+      const ws = protocols !== undefined ? new WebSocket(url, protocols) : new WebSocket(url);
       this.ws = ws;
 
       ws.onopen = () => {

--- a/ui/src/chat/index.ts
+++ b/ui/src/chat/index.ts
@@ -10,7 +10,11 @@ export {
   type UseAgentChatOptions,
   type ChatMessage as ChatMessageData,
 } from './useAgentChat';
-export { WebSocketChatClient, type WebSocketChatClientOptions } from './WebSocketChatClient';
+export {
+  WebSocketChatClient,
+  type WebSocketChatClientOptions,
+  type ChatConnectionTarget,
+} from './WebSocketChatClient';
 export type {
   ServerMessage,
   AgentStreamEventBody,

--- a/ui/src/chat/useAgentChat.ts
+++ b/ui/src/chat/useAgentChat.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { WebSocketChatClient } from './WebSocketChatClient';
+import { WebSocketChatClient, type ChatConnectionTarget } from './WebSocketChatClient';
 import type { ConnectionStatus, ServerMessage } from './protocol';
 
 // useAgentChat owns the connection lifecycle (reconnect/backoff), the
 // transport, and the streaming state. An app supplies `getConnectionUrl`
-// (which calls the backend presigned-URL endpoint with its auth) and a
-// `sessionId`, and gets back everything needed to render a streaming chat.
+// (which calls the backend /agent/connect endpoint with its auth and attaches
+// the bearer subprotocol) and a `sessionId`, and gets back everything needed to
+// render a streaming chat.
 
 export interface ChatMessage {
   id: string;
@@ -21,8 +22,11 @@ export interface UseAgentChatOptions {
   sessionId: string;
   /** Verified user id; forwarded to the agent for memory scoping. */
   userId?: string;
-  /** Returns a presigned wss:// URL (the app calls its backend with auth here). */
-  getConnectionUrl: (sessionId?: string) => Promise<string>;
+  /**
+   * Returns the wss:// URL (and optional bearer subprotocols) for a session —
+   * the app calls its backend with auth here. See {@link ChatConnectionTarget}.
+   */
+  getConnectionUrl: (sessionId?: string) => Promise<ChatConnectionTarget>;
   /** Connect on mount (default true). */
   autoConnect?: boolean;
 }


### PR DESCRIPTION
Replace the hand-rolled SigV4 presigned-URL flow with AgentCore's native
inbound auth. The runtime now carries a CustomJWTAuthorizerConfiguration that
validates the shared Cognito pool; the browser presents its Cognito ID token as
an OAuth bearer in the WebSocket handshake (Sec-WebSocket-Protocol), and the
runtime reads the verified sub from the forwarded Authorization header.

- template.yaml: add AuthorizerConfiguration (AllowedAudience = app client id,
  since the UI issues ID tokens) to AgentCoreRuntime; drop the invoke IAM perms
  from the connect Lambda (auth is now the caller's JWT, not the Lambda role);
  refresh the proxy comments (forwards the bearer subprotocol, nothing signed).
- functions/websocket-connect.mjs: strip the SigV4/smithy presign; return a
  plain wss:// URL with the runtime session id as a query param.
- package.json: remove the now-unused @smithy/* and @aws-crypto/sha256-js deps.
- agent-runtime: decode the verified sub from the Authorization header; drop the
  client-supplied user_id fallback so identity is cryptographically established.
- ui/chat: getConnectionUrl may return { url, protocols } so the app attaches
  the bearer subprotocol; the client stays auth-agnostic. Tests + docs updated.
- README/AGENTS: document the JWT-bearer flow and add verify-on-deploy notes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PS9TRVUjURfWy2QrP5tCpN