### PR TITLE
Hotfix: correct the AuthorizerConfiguration property key (CustomJWTAuthorizer)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -806,7 +806,11 @@ Resources:
       # claim. AgentCore matches the token's `aud` against this list. If you ever
       # switch the UI to access tokens, use AllowedClients instead.
       AuthorizerConfiguration:
-        CustomJWTAuthorizerConfiguration:
+        # Property key is `CustomJWTAuthorizer` (NOT ...Configuration — that's the
+        # schema's definition name). AuthorizerConfiguration is additionalProperties:
+        # false, so the wrong key fails CloudFormation early validation
+        # (AWS::EarlyValidation::PropertyValidation) at changeset creation.
+        CustomJWTAuthorizer:
           DiscoveryUrl: !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPool}/.well-known/openid-configuration'
           AllowedAudience:
             - !Ref CognitoUserPoolClient


### PR DESCRIPTION
## Problem

Deploying `main` (with #208's inbound JWT authorizer) fails CloudFormation early validation at changeset creation:

```
The following hook(s)/validation failed: [AWS::EarlyValidation::PropertyValidation]
```

## Root cause

`AWS::EarlyValidation::PropertyValidation` means a property value is invalid per the resource schema — **not** a name conflict. #208 nested the JWT config under the wrong key:

```yaml
AuthorizerConfiguration:
  CustomJWTAuthorizerConfiguration:   # ← schema *definition* name, not the property key
```

The published `AWS::BedrockAgentCore::Runtime` schema defines the property as **`CustomJWTAuthorizer`**:

```json
"AuthorizerConfiguration": {
  "properties": { "CustomJWTAuthorizer": { "$ref": "#/definitions/CustomJWTAuthorizerConfiguration" } },
  "additionalProperties": false
}
```

Because `AuthorizerConfiguration` is `additionalProperties: false`, the wrong key is rejected before deploy.

## Fix

Rename the key `CustomJWTAuthorizerConfiguration` → `CustomJWTAuthorizer`. One word; the `DiscoveryUrl` and `AllowedAudience` underneath are already correct per the schema (`AllowedAudience` is a valid string list; `DiscoveryUrl` is required).

Confirmed against `https://schema.cloudformation.<region>.amazonaws.com/aws-bedrockagentcore-runtime.json`. The same source shows `createOnlyProperties` is **only** `AgentRuntimeName`, so `AuthorizerConfiguration` is mutable — this is an in-place update to the existing runtime, **no replacement and no rename needed** (earlier iterations of this branch that renamed the runtime / rewrapped `AllowedAudience` were wrong theories and have been dropped; the branch is now a single one-word commit).

## Follow-up

The same wrong key is in #210 (managed Memory), which is based on the post-#208 main. Merging this first and rebasing #210 fixes it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS9TRVUjURfWy2QrP5tCpN