### PR TITLE
#199: forward the connecting user's live token to opted-in MCP servers

### DIFF
--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -7,7 +7,7 @@ import {
   handleUserMessage,
   getSessionConfig,
   resolveTools,
-  type McpServerSpec,
+  resolveMcpServerConfigs,
   type ServerMessage,
   type ToolRegistry,
 } from '@readysetcloud/agent';
@@ -74,6 +74,30 @@ function getUserId(context: RequestContext): string | undefined {
   return key ? context.headers[key] : undefined;
 }
 
+/**
+ * The connecting user's live bearer token (no `Bearer ` prefix) — the Cognito
+ * token AgentCore Inbound Auth validated for this connection, forwarded as the
+ * Authorization header. Used to forward a fresh, per-connection token to a
+ * session's opted-in gateway MCP servers (rsc-core #199) instead of a value
+ * baked into the session config that would go stale at ~1h.
+ */
+function getBearerToken(context: RequestContext): string | undefined {
+  const authKey = Object.keys(context.headers).find(
+    (h) => h.toLowerCase() === 'authorization',
+  );
+  const raw = authKey ? context.headers[authKey] : undefined;
+  return raw ? raw.replace(/^Bearer\s+/i, '') : undefined;
+}
+
+// Hosts the runtime may forward the connecting user's live token to (#199).
+// Forwarding a real user credential to any other host is refused. Reuses the
+// same allowlist create-session enforces for a session's MCP hosts (#196); empty
+// forwards to nothing.
+const MCP_ALLOWED_HOSTS = (process.env.MCP_ALLOWED_HOSTS ?? '')
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean);
+
 // First-party tools this host offers for session selection. A session enables a
 // tool by adding its name to `tools` in the session config; unknown names are
 // skipped. Register your own tools here — SELECTING a tool per session is a data
@@ -88,33 +112,6 @@ const TOOL_REGISTRY: ToolRegistry = {
       callback: async () => new Date().toISOString(),
     }),
 };
-
-/**
- * Maps a session's declarative MCP specs to the Strands SDK's connection config,
- * folding each spec's authority-minted `authHeader` into the outbound HTTP
- * headers (rsc-core issue #197). The header carries the verified user's identity
- * to the MCP server: the authority (session creator) signs the identity/scope
- * server-side and stores the token on the spec; this runtime is a dumb courier
- * that forwards it verbatim and never interprets it.
- *
- * `authHeader` is applied AFTER the user-supplied `headers`, so a session's own
- * headers can't shadow the identity header. The token value is opaque (base64url
- * payload + signature) and contains no `${...}`, so the SDK's env interpolation
- * over header values leaves it untouched — it is passed through literally.
- */
-function toMcpServerConfigs(
-  specs: Record<string, McpServerSpec>,
-): Record<string, McpServerConfig> {
-  const configs: Record<string, McpServerConfig> = {};
-  for (const [name, spec] of Object.entries(specs)) {
-    const { authHeader, ...rest } = spec;
-    if (authHeader?.name) {
-      rest.headers = { ...rest.headers, [authHeader.name]: authHeader.value };
-    }
-    configs[name] = rest as McpServerConfig;
-  }
-  return configs;
-}
 
 // The AWS::BedrockAgentCore::Memory resource id (template.yaml). When unset
 // (local/test), the assistant runs without cross-session memory.
@@ -186,6 +183,7 @@ async function closeMcpClients(clients: McpClient[]): Promise<void> {
 async function buildAgentForSession(
   sessionId: string,
   userId: string | undefined,
+  connectionToken?: string,
 ): Promise<{ agent: Agent; mcpClients: McpClient[] } | null> {
   const config = await getSessionConfig(sessionId);
   if (config && config.userId !== userId) {
@@ -196,10 +194,17 @@ async function buildAgentForSession(
 
   // External tools: connect to any MCP servers the session declared. The specs
   // are validated + host-allowlisted at session-create time (create-session.mjs).
+  // resolveMcpServerConfigs folds in each server's identity mechanism: a static
+  // `authHeader` (#197), or — for a server that opts in — the connecting user's
+  // live bearer token, forwarded only to allowlisted hosts (#199).
   let mcpClients: McpClient[] = [];
   const mcpServers = config?.mcpServers;
   if (mcpServers && Object.keys(mcpServers).length > 0) {
-    mcpClients = await McpClient.loadServers(toMcpServerConfigs(mcpServers));
+    const configs = resolveMcpServerConfigs(mcpServers, {
+      connectionToken,
+      allowedHosts: MCP_ALLOWED_HOSTS,
+    }) as Record<string, McpServerConfig>;
+    mcpClients = await McpClient.loadServers(configs);
   }
 
   const agent = createAssistant({
@@ -231,7 +236,7 @@ const app = new BedrockAgentCoreApp({
       const sessionId = req.session_id ?? context.sessionId;
       // Verified JWT identity wins; req.user_id is only a local/debug fallback.
       const userId = getUserId(context) ?? req.user_id;
-      const built = await buildAgentForSession(sessionId, userId);
+      const built = await buildAgentForSession(sessionId, userId, getBearerToken(context));
       if (!built) {
         return {
           request: req.request,
@@ -254,6 +259,11 @@ const app = new BedrockAgentCoreApp({
   // conversation, recreating the agent when the client switches sessions.
   websocketHandler: async (socket: WebSocket, context: RequestContext) => {
     const userId = getUserId(context);
+    // Captured once at connect; a session's opted-in gateway MCP servers get this
+    // live token (#199). It's the browser's current Cognito token, so each new
+    // connection refreshes it — grounding survives past the token's ~1h life via
+    // reconnect (a single connection held longer re-grounds on its next connect).
+    const connectionToken = getBearerToken(context);
     let agent: Agent | null = null;
     let sessionId: string | null = null;
     let mcpClients: McpClient[] = [];
@@ -292,7 +302,7 @@ const app = new BedrockAgentCoreApp({
         // loading that session's stored config, tools, and MCP servers and
         // enforcing ownership. Disconnect the previous session's MCP clients.
         if (agent === null || msgSessionId !== sessionId) {
-          const built = await buildAgentForSession(msgSessionId, userId);
+          const built = await buildAgentForSession(msgSessionId, userId, connectionToken);
           if (!built) {
             send({ type: 'error', error: 'Session does not belong to this user' });
             return;

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/agent",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1085.0",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Portable, framework-agnostic Node agent core for Ready, Set, Cloud: a Strands-TS assistant with DynamoDB-backed conversation snapshots and pluggable cross-session memory.",
   "author": "allenheltondev",
   "license": "MIT",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -50,6 +50,13 @@ export {
   type McpServerSpec,
 } from './memory/sessions.js';
 
+// MCP spec → connection config resolution (authHeader + connection-token forwarding).
+export {
+  resolveMcpServerConfigs,
+  type ResolveMcpOptions,
+  type ResolvedMcpServerConfig,
+} from './memory/mcp-config.js';
+
 // Event-driven session creation (a separate stack requests a session over the
 // default bus; the owning stack consumes it). See ./memory/session-events.
 export {

--- a/agent/src/memory/index.ts
+++ b/agent/src/memory/index.ts
@@ -17,6 +17,11 @@ export {
   type McpServerSpec,
 } from './sessions.js';
 export {
+  resolveMcpServerConfigs,
+  type ResolveMcpOptions,
+  type ResolvedMcpServerConfig,
+} from './mcp-config.js';
+export {
   requestSession,
   createSessionFromEvent,
   SESSION_REQUEST_SOURCE,

--- a/agent/src/memory/mcp-config.test.ts
+++ b/agent/src/memory/mcp-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMcpServerConfigs } from './mcp-config.js';
+
+const GW = 'https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp';
+
+describe('resolveMcpServerConfigs', () => {
+  it('folds a static authHeader into headers, after user headers, and strips the field', () => {
+    const out = resolveMcpServerConfigs({
+      blog: { url: GW, headers: { 'x-v': '1' }, authHeader: { name: 'x-auth', value: 'tok' } },
+    });
+    expect(out.blog.headers).toEqual({ 'x-v': '1', 'x-auth': 'tok' });
+    expect('authHeader' in out.blog).toBe(false);
+  });
+
+  it('forwards the connection token as Authorization for an allowlisted host', () => {
+    const out = resolveMcpServerConfigs(
+      { blog: { url: GW, transport: 'streamable-http', forwardConnectionToken: true } },
+      { connectionToken: 'jwt-123', allowedHosts: ['gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com'] },
+    );
+    expect(out.blog.headers).toEqual({ Authorization: 'Bearer jwt-123' });
+    expect('forwardConnectionToken' in out.blog).toBe(false);
+  });
+
+  it('REFUSES to forward the token to a non-allowlisted host (no credential leak)', () => {
+    const out = resolveMcpServerConfigs(
+      { evil: { url: 'https://attacker.example/mcp', forwardConnectionToken: true } },
+      { connectionToken: 'jwt-123', allowedHosts: ['gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com'] },
+    );
+    expect(out.evil.headers?.Authorization).toBeUndefined();
+  });
+
+  it('does not forward when there is no connection token, or the allowlist is empty', () => {
+    const noToken = resolveMcpServerConfigs(
+      { blog: { url: GW, forwardConnectionToken: true } },
+      { allowedHosts: ['gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com'] },
+    );
+    expect(noToken.blog.headers?.Authorization).toBeUndefined();
+
+    const noAllowlist = resolveMcpServerConfigs(
+      { blog: { url: GW, forwardConnectionToken: true } },
+      { connectionToken: 'jwt-123' }, // allowedHosts defaults to []
+    );
+    expect(noAllowlist.blog.headers?.Authorization).toBeUndefined();
+  });
+
+  it('leaves a server without either mechanism untouched', () => {
+    const out = resolveMcpServerConfigs({ docs: { url: 'https://tools.example/mcp' } });
+    expect(out.docs).toEqual({ url: 'https://tools.example/mcp' });
+  });
+});

--- a/agent/src/memory/mcp-config.ts
+++ b/agent/src/memory/mcp-config.ts
@@ -1,0 +1,73 @@
+import type { McpServerSpec } from './sessions.js';
+
+// Resolves a session's declarative MCP specs into connection configs the Strands
+// SDK consumes, folding the two identity mechanisms into outbound headers. Kept
+// here (Strands-free, on the ./memory subpath) so the security-sensitive logic —
+// which credential is forwarded to which host — is unit-tested, and the runtime
+// stays a thin caller. The output is plain and JSON-serializable; the caller
+// casts it to the SDK's `McpServerConfig`.
+
+/** The spec minus the fields that resolve into headers. */
+export type ResolvedMcpServerConfig = Omit<McpServerSpec, 'authHeader' | 'forwardConnectionToken'>;
+
+/** Options for {@link resolveMcpServerConfigs}. */
+export interface ResolveMcpOptions {
+  /**
+   * The connecting user's live bearer token (no `Bearer ` prefix). Forwarded as
+   * `Authorization: Bearer <token>` to servers with `forwardConnectionToken`.
+   */
+  connectionToken?: string;
+  /**
+   * Hosts the connection token may be forwarded to. Forwarding a real user
+   * credential to any other host is refused — this is the guard against leaking
+   * the token to an unlisted (e.g. attacker-controlled) MCP endpoint.
+   */
+  allowedHosts?: string[];
+}
+
+function hostAllowed(url: string | undefined, allowedHosts: string[]): boolean {
+  if (!url) return false;
+  try {
+    return allowedHosts.includes(new URL(url).host);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maps `specs` to connection configs, applying (in order):
+ *
+ * 1. **`authHeader`** (rsc-core #197) — an authority-minted token, applied
+ *    verbatim AFTER the user-supplied `headers` so a session can't shadow it.
+ * 2. **`forwardConnectionToken`** (rsc-core #199) — inject the connecting user's
+ *    live bearer as `Authorization`, for a gateway whose authorizer validates the
+ *    end user's token. Applied ONLY when a `connectionToken` is present AND the
+ *    server's host is in `allowedHosts`; otherwise it is silently skipped (never
+ *    forward a real user credential to an unlisted host).
+ *
+ * The `authHeader`/`forwardConnectionToken` fields themselves are stripped from
+ * the returned config (they are not SDK connection fields).
+ */
+export function resolveMcpServerConfigs(
+  specs: Record<string, McpServerSpec>,
+  options: ResolveMcpOptions = {},
+): Record<string, ResolvedMcpServerConfig> {
+  const { connectionToken, allowedHosts = [] } = options;
+  const configs: Record<string, ResolvedMcpServerConfig> = {};
+
+  for (const [name, spec] of Object.entries(specs)) {
+    const { authHeader, forwardConnectionToken, ...rest } = spec;
+
+    if (authHeader?.name) {
+      rest.headers = { ...rest.headers, [authHeader.name]: authHeader.value };
+    }
+
+    if (forwardConnectionToken && connectionToken && hostAllowed(rest.url, allowedHosts)) {
+      rest.headers = { ...rest.headers, Authorization: `Bearer ${connectionToken}` };
+    }
+
+    configs[name] = rest;
+  }
+
+  return configs;
+}

--- a/agent/src/memory/sessions.ts
+++ b/agent/src/memory/sessions.ts
@@ -59,6 +59,20 @@ export interface McpServerSpec {
     /** Opaque authority-minted token (e.g. `<base64url(payload)>.<sig>`). */
     value: string;
   };
+  /**
+   * When true, the runtime injects the **connecting user's live bearer token**
+   * (the Cognito token AgentCore Inbound Auth validated for this connection) as
+   * this server's `Authorization` header — a fresh, per-connection token rather
+   * than a value baked into this row (rsc-core #199). Use it for a gateway MCP
+   * server whose inbound JWT authorizer validates the *end user's* token and
+   * reads its `sub` (e.g. Booked's blog-search AgentCore Gateway), where a static
+   * `authHeader` would go stale when the token expires (~1h).
+   *
+   * Because this forwards a real user credential, the runtime only honors it for
+   * hosts on its MCP allowlist. It's an alternative to `authHeader` (a static
+   * authority token) — set one or the other.
+   */
+  forwardConnectionToken?: boolean;
   /** Explicit transport; auto-detected from the fields present when omitted. */
   transport?: 'stdio' | 'sse' | 'streamable-http';
   /** Command to spawn (stdio transport). */

--- a/template.yaml
+++ b/template.yaml
@@ -938,6 +938,10 @@ Resources:
         AGENT_MEMORY_ID: !GetAtt AgentMemory.MemoryId
         BEDROCK_MODEL_ID: !Ref BedrockModelId
         BEDROCK_REGION: !Ref AWS::Region
+        # Hosts the runtime may forward the connecting user's live token to for a
+        # session's `forwardConnectionToken` MCP servers (#199) — same allowlist
+        # create-session enforces (#196). Empty forwards to nothing (fails closed).
+        MCP_ALLOWED_HOSTS: !Ref McpAllowedHosts
 
   AgentCoreRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Closes #199.

## Why

Booked's "Ask your blog" grounding is an **AgentCore Gateway** whose inbound JWT authorizer validates the **end user's** Cognito token and whose interceptor reads the `sub`. For a session to reach it, the runtime must present a **fresh, non-expired** user token. Today the runtime only attaches the static `authHeader` baked into the session config (#197) — a Cognito token stored there goes stale at ~1h, so grounding breaks.

## What

The runtime already holds the user's live token (AgentCore Inbound Auth forwards it as `Authorization`; `getUserId` decodes the `sub` from it). This wires that token through to servers that opt in.

- **Package** (`@readysetcloud/agent`): `McpServerSpec.forwardConnectionToken?: boolean`, plus a tested `resolveMcpServerConfigs(specs, { connectionToken, allowedHosts })` that folds either a static `authHeader` (#197) **or** the live bearer (#199) into outbound headers. Forwarding a real user credential is **gated on an allowlist** — never sent to an unlisted host.
- **Runtime** (`agent-runtime`): captures the connection bearer (`getBearerToken`), threads it through `buildAgentForSession`, and uses the resolver with `MCP_ALLOWED_HOSTS`. Replaces the local `toMcpServerConfigs`.
- **Template**: `MCP_ALLOWED_HOSTS` on the runtime (from the existing `McpAllowedHosts` param — the same allowlist `create-session` enforces, #196).

## Refresh semantics

Per **connection**: the token is captured at connect, so each browser reconnect (with a freshly-refreshed Cognito token) re-grounds automatically. Bounded by the token's ~1h life on a single continuously-open socket — never-stale mid-connection is a later option (AgentCore Identity token vending, #199 option 2), not needed given the accepted 1h window.

## Security

`forwardConnectionToken` forwards a **real user credential**, so the runtime only honors it for hosts in `MCP_ALLOWED_HOSTS` (empty → forwards to nothing, fails closed). Covered by `mcp-config.test.ts` including the refusal-to-forward-to-unlisted-host case.

## Follow-ups (separate)

- Booked flips its session to `mcpServers.blog = { url, transport, forwardConnectionToken: true }` (drops the baked Cognito `authHeader`) once this deploys.
- Set `McpAllowedHosts` to include the `BlogGatewayUrl` host at deploy (#196).

## Verify

62 package tests pass (5 new for the resolver); package + runtime typecheck/build clean; runtime esbuild-bundles; cfn-lint unchanged (only the pre-existing NODE_22/NamespaceTemplates gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)