### PR TITLE
Add runAgent: stateless one-shot server-side invocation primitive

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -30,6 +30,8 @@ Strands SDK and `zod`.
 | `createSession({ userId, systemPrompt?, modelId?, temperature?, maxTokens?, title?, tools?, mcpServers?, sessionId?, tableName? })`, `getSessionConfig(sessionId, tableName?)` | Per-session config so a generic host loads prompt/model/tools by `sessionId` at connect (no redeploy to change behavior). `createSession` sets the owner; the host enforces it. `tools` selects first-party tools by name; `mcpServers` attaches external MCP tool sources (see [MCP servers](#mcp-servers-external-tools)). Also on the `./memory` subpath. |
 | `runAgentTask({ taskId, principal, request, buildAgent, … })` | Runs one autonomous (non-chat) task to completion in the host: warm-cache → idempotent claim → `buildAgent` → run → record row → emit result event. See [Autonomous tasks](#autonomous-tasks-non-chat-agents). |
 | `handleTask(agent, { request })` | Buffered sibling of `handleUserMessage`: invokes the agent, flushes memory, returns the final text — no streaming. The single-turn primitive `runAgentTask` wraps. |
+| `runAgent({ input, systemPrompt?, modelId?, tools?, outputSchema?, maxIterations?, invocationState?, … })` | Stateless one-shot server-side invocation — build-and-discard, no session/snapshot/table. Enforces a Zod `outputSchema` (returns the validated object), bounds tool loops with `maxIterations`, and injects trusted per-call context via `invocationState`. See [Server-side one-shot runs](#server-side-one-shot-runs-runagent). |
+| `tool({ name, description, inputSchema, callback })` | Re-export of the Strands tool-definition helper, so hosts define tools without importing the SDK directly. Handlers read trusted context from `context.invocationState`. |
 | `createTask` / `startTask` / `finishTask` / `getTask`, `requestAgentTask` / `emitTaskCompleted`, `TaskResultCache` | The autonomous-task data plane: durable task rows (idempotent lifecycle), the EventBridge trigger/result contract, and an in-memory result cache. All Strands-free (on `./memory`). |
 | `streamTurn(stream, { sessionId, send })`, `toStreamEventBodies(event)` | Streaming primitives / the SDK→wire normalizer (the one SDK coupling point). |
 | `DynamoSnapshotStorage` | Implements Strands' `SnapshotStorage` port against the single table. |
@@ -231,6 +233,99 @@ Pass it to run the agent in **your own** stack against **your own** table
 (library mode) instead of through a shared host. Note the boundary: a library-mode
 run does not go through the shared runtime's guarantees (Bedrock grant, MCP
 allowlist, memory isolation) — your stack owns them.
+
+## Server-side one-shot runs (`runAgent`)
+
+`runAgent` is the bare primitive: build a Strands `Agent`, run **one** turn to
+completion, return the answer. No session manager, no snapshots, no DynamoDB —
+nothing persists, so it needs no table and leaves no trace. Where
+`handleUserMessage` streams a chat turn to a browser and `runAgentTask` wraps a
+run in a durable, idempotent task record, `runAgent` is what a **server-side
+orchestrator** (e.g. a Lambda fanning one input across several independent
+analyses) reaches for when each analysis is an isolated call.
+
+```ts
+import { runAgent } from '@readysetcloud/agent';
+import { z } from 'zod';
+
+// One-shot STRUCTURED analysis — no prose parsing, get a validated object.
+const grammar = await runAgent({
+  input: draft,
+  modelId: 'us.anthropic.claude-lite-...',   // pin a model per lens
+  systemPrompt: 'You are a grammar & spelling reviewer.',
+  outputSchema: z.object({
+    suggestions: z.array(z.object({ span: z.string(), fix: z.string() })),
+  }),
+});
+grammar.output.suggestions;   // typed, schema-validated — not a string
+```
+
+- **Structured output enforcement.** Pass `outputSchema` (a Zod schema) and the
+  SDK forces the model to emit against it; `output` is the validated object and
+  `structured` is `true`. If the model can't produce a conforming result even
+  after being forced, the SDK throws — a resolved call is a schema-valid one.
+  Omit the schema and `output` is the response text.
+- **Bounded tool loops.** Pass `tools` (first-party `tool()`s, an `McpClient`,
+  or a sub-agent) for a tool-using analysis — a fact lens over web
+  search/fetch — and cap the loop with `maxIterations` (mapped to the SDK's
+  per-invocation `limits.turns`) so it can't run away.
+- **Per-lens model selection.** `modelId` pins a Pro- vs Lite-tier model for
+  this call; different lenses pick different models.
+- **Trusted context injection.** `invocationState` is threaded to every tool's
+  execution context (`context.invocationState`) and returned on the result. It
+  is the injection point for values the model **must not supply or forge** — a
+  `tenantId`, the caller's verified `sub`. Because it is not a tool input
+  parameter, the model never sees or sets it; trusted code sets it, handlers
+  read it:
+
+  ```ts
+  import { runAgent, tool } from '@readysetcloud/agent';
+  import { z } from 'zod';
+
+  const searchBlog = tool({
+    name: 'search_blog',
+    description: "Search the tenant's own posts",
+    inputSchema: z.object({ query: z.string() }),   // model supplies only this
+    callback: async ({ query }, context) => {
+      const tenantId = context?.invocationState.tenantId as string;  // trusted, not model-supplied
+      return searchWithinTenant(tenantId, query);
+    },
+  });
+
+  const facts = await runAgent({
+    input: draft,
+    systemPrompt: 'Fact-check claims using the blog search tool.',
+    tools: [searchBlog],
+    maxIterations: 6,
+    invocationState: { tenantId, sub },   // injected by trusted code
+  });
+  ```
+
+**Multi-lens engine sketch.** Each lens is an independent `runAgent` call; the
+orchestrator fans them out and (optionally) synthesizes:
+
+```ts
+const [grammar, llm, facts] = await Promise.all([
+  runAgent({ input, systemPrompt: GRAMMAR, outputSchema: GrammarSchema }),
+  runAgent({ input, systemPrompt: LLM_DETECT, outputSchema: DetectSchema }),
+  runAgent({ input, systemPrompt: FACTS, tools: [searchBlog], maxIterations: 6,
+             invocationState: { tenantId, sub } }),
+]);
+
+const summary = await runAgent({
+  input: JSON.stringify({ grammar: grammar.output, llm: llm.output, facts: facts.output }),
+  systemPrompt: SUMMARY,
+  outputSchema: SummarySchema,
+});
+```
+
+To attach an **MCP** web-search/fetch gateway to a lens instead of first-party
+tools, connect it and pass the client in `tools` — see [MCP servers](#mcp-servers-external-tools)
+for how the runtime resolves specs and forwards verified identity via
+`authHeader`. For a **durable** orchestrator (idempotent under at-least-once
+delivery), run the outer call as a task (`runAgentTask`) and let its lenses call
+`runAgent`. Streaming a run's tokens is not covered here — `runAgent` buffers
+the final answer.
 
 ## MCP servers (external tools)
 

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/agent",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1085.0",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Portable, framework-agnostic Node agent core for Ready, Set, Cloud: a Strands-TS assistant with DynamoDB-backed conversation snapshots and pluggable cross-session memory.",
   "author": "allenheltondev",
   "license": "MIT",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -18,6 +18,20 @@ export {
   type BuiltTaskAgent,
 } from './task.js';
 
+// Stateless one-shot server-side invocation — the bare primitive with structured
+// output, bounded tool loops, and trusted context injection (no session/snapshot).
+export {
+  runAgent,
+  type RunAgentOptions,
+  type RunAgentResult,
+} from './run.js';
+
+// The SDK's tool-definition helper, re-exported so hosts define tools (name,
+// description, input schema, handler) without importing the SDK directly. A tool
+// handler reads trusted per-run context from `context.invocationState` (see
+// runAgent) — the model supplies only the declared input schema, never that.
+export { tool } from '@strands-agents/sdk';
+
 // Wire protocol (shared with the UI client).
 export type {
   ServerMessage,

--- a/agent/src/run.test.ts
+++ b/agent/src/run.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+// Capture what runAgent builds + how it invokes the SDK agent, and control the
+// result. We fake Agent/BedrockModel and keep the rest of the SDK intact.
+const invoke = vi.fn();
+const agentConfigs: unknown[] = [];
+const modelConfigs: unknown[] = [];
+
+vi.mock('@strands-agents/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@strands-agents/sdk')>();
+  return {
+    ...actual,
+    BedrockModel: class {
+      constructor(config: unknown) {
+        modelConfigs.push(config);
+      }
+    },
+    Agent: class {
+      constructor(config: unknown) {
+        agentConfigs.push(config);
+      }
+      invoke = (...args: unknown[]) => invoke(...args);
+    },
+  };
+});
+
+const { runAgent } = await import('./run.js');
+
+const makeResult = (over: Record<string, unknown> = {}) => ({
+  toString: () => 'plain text answer',
+  stopReason: 'endTurn',
+  invocationState: {},
+  structuredOutput: undefined,
+  ...over,
+});
+
+beforeEach(() => {
+  invoke.mockReset();
+  agentConfigs.length = 0;
+  modelConfigs.length = 0;
+});
+
+describe('runAgent', () => {
+  it('returns response text when no schema is given', async () => {
+    invoke.mockResolvedValue(makeResult({ toString: () => 'hello' }));
+
+    const result = await runAgent({ input: 'say hi' });
+
+    expect(invoke).toHaveBeenCalledWith('say hi', expect.any(Object));
+    expect(result).toMatchObject({ output: 'hello', text: 'hello', structured: false, stopReason: 'endTurn' });
+  });
+
+  it('builds a stateless agent — no session manager, no storage', async () => {
+    invoke.mockResolvedValue(makeResult());
+
+    await runAgent({ input: 'x' });
+
+    const config = agentConfigs[0] as Record<string, unknown>;
+    expect(config).not.toHaveProperty('sessionManager');
+    expect(config).not.toHaveProperty('memoryManager');
+    expect(config).not.toHaveProperty('storage');
+  });
+
+  it('pins the per-call model id and passes prompt + tools through', async () => {
+    invoke.mockResolvedValue(makeResult());
+    const tool = { name: 'search' };
+
+    await runAgent({
+      input: 'x',
+      modelId: 'us.anthropic.claude-pro',
+      systemPrompt: 'You are the grammar lens.',
+      tools: [tool] as never,
+    });
+
+    expect(modelConfigs[0]).toMatchObject({ modelId: 'us.anthropic.claude-pro' });
+    const config = agentConfigs[0] as Record<string, unknown>;
+    expect(config).toMatchObject({ systemPrompt: 'You are the grammar lens.', tools: [tool] });
+  });
+
+  it('enforces a schema and returns the validated object', async () => {
+    const schema = z.object({ score: z.number(), issues: z.array(z.string()) });
+    const structuredOutput = { score: 3, issues: ['comma splice'] };
+    invoke.mockResolvedValue(makeResult({ structuredOutput, toString: () => JSON.stringify(structuredOutput) }));
+
+    const result = await runAgent({ input: 'review this', outputSchema: schema });
+
+    // The schema is forwarded to the SDK's per-invocation structured-output path.
+    expect(invoke).toHaveBeenCalledWith('review this', expect.objectContaining({ structuredOutputSchema: schema }));
+    expect(result.structured).toBe(true);
+    expect(result.output).toEqual(structuredOutput);
+  });
+
+  it('throws when a schema was requested but no structured output came back', async () => {
+    const schema = z.object({ score: z.number() });
+    invoke.mockResolvedValue(makeResult({ structuredOutput: undefined }));
+
+    await expect(runAgent({ input: 'x', outputSchema: schema })).rejects.toThrow(/no structured output/);
+  });
+
+  it('maps maxIterations to the SDK per-invocation turns limit', async () => {
+    invoke.mockResolvedValue(makeResult());
+
+    await runAgent({ input: 'x', maxIterations: 4 });
+
+    expect(invoke).toHaveBeenCalledWith('x', expect.objectContaining({ limits: { turns: 4 } }));
+  });
+
+  it('rejects a non-positive / non-integer maxIterations before invoking', async () => {
+    await expect(runAgent({ input: 'x', maxIterations: 0 })).rejects.toThrow(/positive integer/);
+    await expect(runAgent({ input: 'x', maxIterations: 2.5 })).rejects.toThrow(/positive integer/);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('threads trusted invocationState to the invocation and surfaces it back', async () => {
+    const injected = { tenantId: 'tenant-42', sub: 'user-9' };
+    invoke.mockResolvedValue(makeResult({ invocationState: injected }));
+
+    const result = await runAgent({ input: 'x', invocationState: injected });
+
+    expect(invoke).toHaveBeenCalledWith('x', expect.objectContaining({ invocationState: injected }));
+    expect(result.invocationState).toEqual(injected);
+  });
+
+  it('omits optional invoke options when not provided', async () => {
+    invoke.mockResolvedValue(makeResult());
+
+    await runAgent({ input: 'x' });
+
+    const opts = invoke.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty('structuredOutputSchema');
+    expect(opts).not.toHaveProperty('limits');
+    expect(opts).not.toHaveProperty('invocationState');
+    expect(opts).not.toHaveProperty('cancelSignal');
+  });
+});

--- a/agent/src/run.ts
+++ b/agent/src/run.ts
@@ -1,0 +1,175 @@
+import { Agent, BedrockModel, type AgentConfig } from '@strands-agents/sdk';
+import type { z } from 'zod';
+import {
+  DEFAULT_MODEL_ID,
+  DEFAULT_REGION,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_TEMPERATURE,
+  DEFAULT_SYSTEM_PROMPT,
+} from './config.js';
+
+// A stateless, server-side, one-shot invocation of the agent. Where
+// `handleUserMessage` (agent.ts) streams a chat turn to a browser and
+// `runAgentTask` (task.ts) wraps a run in a durable, idempotent task record,
+// `runAgent` is the bare primitive: build a Strands `Agent`, run one turn to
+// completion, hand back the answer. No session manager, no snapshots, no
+// DynamoDB — nothing persists, so it needs no table and leaves no trace.
+//
+// This is the shape a server-side orchestrator (e.g. a multi-lens content
+// review engine running in a Lambda) reaches for when it wants to fan a single
+// input across several independent analyses, each an isolated call:
+//
+//   - a one-shot **structured** analysis (grammar, LLM-detection) — pass an
+//     `outputSchema` and get a validated object back, no prose parsing;
+//   - a **tool-using** analysis (fact-checking over web search/fetch) — pass
+//     `tools` and cap the loop with `maxIterations`;
+//   - a **per-lens model** — pass `modelId` to pin a Pro- vs Lite-tier model.
+//
+// Trusted context (a `tenantId`, the caller's `sub`) is injected through
+// `invocationState`, which the SDK threads to every tool's execution context.
+// Because it is not a tool input parameter, the model can neither see nor
+// forge it — trusted code sets it, tool handlers read it.
+
+/** Options for {@link runAgent}. */
+export interface RunAgentOptions {
+  /** The input the agent runs against (the content/instruction for this call). */
+  input: string;
+  /** System prompt; defaults to {@link DEFAULT_SYSTEM_PROMPT}. */
+  systemPrompt?: string;
+  /** Model id for this call; defaults to {@link DEFAULT_MODEL_ID}. Pin it per lens. */
+  modelId?: string;
+  /** Sampling temperature; defaults to {@link DEFAULT_TEMPERATURE}. */
+  temperature?: number;
+  /** Max response tokens; defaults to {@link DEFAULT_MAX_TOKENS}. */
+  maxTokens?: number;
+  /** Bedrock region; defaults to {@link DEFAULT_REGION}. */
+  region?: string;
+  /**
+   * Tools to expose for this call. Accepts anything the Strands `Agent` does — a
+   * `tool()`, an `McpClient`, or a sub-`Agent` — so a lens can fact-check over an
+   * MCP web-search gateway or call first-party handlers. Omit for a pure
+   * (tool-free) structured/text analysis.
+   */
+  tools?: AgentConfig['tools'];
+  /**
+   * Zod schema the final answer is validated against. When set, the SDK forces
+   * the model to emit against the schema and {@link RunAgentResult.output} is the
+   * validated object (not prose). When omitted, `output` is the response text.
+   */
+  outputSchema?: z.ZodType;
+  /**
+   * Upper bound on agent-loop iterations (a turn = one model call plus any tool
+   * execution that follows), mapped to the SDK's per-invocation `limits.turns`.
+   * The contract for bounded tool loops: a fact lens that keeps searching can't
+   * run away. Omit for no cap. Must be a positive integer when set.
+   */
+  maxIterations?: number;
+  /**
+   * Trusted, request-scoped context threaded to every tool's execution context
+   * (`context.invocationState`) and returned on the result. This is the
+   * injection point for values the model must not supply or forge — a
+   * `tenantId`, the caller's verified `sub`. Tool handlers read it from context;
+   * it is never exposed to the model as an input parameter.
+   */
+  invocationState?: Record<string, unknown>;
+  /**
+   * External abort signal (e.g. a request-deadline timeout). When it fires the
+   * run stops at the next checkpoint and the call rejects.
+   */
+  cancelSignal?: AbortSignal;
+}
+
+/** Result of a {@link runAgent} call. */
+export interface RunAgentResult<T = unknown> {
+  /**
+   * The run's answer: the schema-validated object when `outputSchema` was passed,
+   * otherwise the response text.
+   */
+  output: T;
+  /** The response's string form (JSON for a structured result), always present. */
+  text: string;
+  /** Whether {@link output} is a schema-validated object (true) or text (false). */
+  structured: boolean;
+  /** The final model stop reason (`'endTurn'`, `'limitTurns'`, …). */
+  stopReason: string;
+  /** The `invocationState` after the run (tools/hooks may have mutated it). */
+  invocationState: Record<string, unknown>;
+}
+
+/**
+ * Runs one stateless turn of the agent to completion and returns its answer.
+ *
+ * With an `outputSchema` the result is the validated object; the SDK forces the
+ * structured-output tool and throws `StructuredOutputError` if the model can't
+ * produce a conforming result even after being forced — so a resolved call is a
+ * schema-valid one. With `tools`, cap the loop with `maxIterations`. Inject
+ * trusted per-call context (tenant, caller identity) through `invocationState`.
+ *
+ * Nothing here persists: no session manager, no snapshot storage, no table.
+ * Construct-and-discard per call — ideal for a server-side orchestrator running
+ * many independent analyses over one input.
+ */
+export async function runAgent<Schema extends z.ZodType>(
+  options: RunAgentOptions & { outputSchema: Schema },
+): Promise<RunAgentResult<z.output<Schema>>>;
+export async function runAgent(
+  options: RunAgentOptions & { outputSchema?: undefined },
+): Promise<RunAgentResult<string>>;
+export async function runAgent(options: RunAgentOptions): Promise<RunAgentResult> {
+  const {
+    input,
+    systemPrompt = DEFAULT_SYSTEM_PROMPT,
+    modelId = DEFAULT_MODEL_ID,
+    temperature = DEFAULT_TEMPERATURE,
+    maxTokens = DEFAULT_MAX_TOKENS,
+    region = DEFAULT_REGION,
+    tools = [],
+    outputSchema,
+    maxIterations,
+    invocationState,
+    cancelSignal,
+  } = options;
+
+  if (maxIterations !== undefined && (!Number.isInteger(maxIterations) || maxIterations < 1)) {
+    throw new Error('runAgent: maxIterations must be a positive integer when provided');
+  }
+
+  const agent = new Agent({
+    model: new BedrockModel({ region, modelId, maxTokens, temperature }),
+    systemPrompt,
+    tools: tools ?? [],
+  });
+
+  const result = await agent.invoke(input, {
+    ...(outputSchema ? { structuredOutputSchema: outputSchema } : {}),
+    ...(maxIterations !== undefined ? { limits: { turns: maxIterations } } : {}),
+    ...(invocationState ? { invocationState } : {}),
+    ...(cancelSignal ? { cancelSignal } : {}),
+  });
+
+  const text = result.toString();
+
+  if (outputSchema) {
+    // The SDK populates `structuredOutput` on success and throws
+    // StructuredOutputError otherwise; guard defensively so a schema request
+    // never silently degrades to prose.
+    if (result.structuredOutput === undefined) {
+      throw new Error('runAgent: an outputSchema was provided but the model returned no structured output');
+    }
+    return {
+      output: result.structuredOutput,
+      text,
+      structured: true,
+      stopReason: result.stopReason,
+      invocationState: result.invocationState,
+    };
+  }
+
+  return {
+    output: text,
+    text,
+    structured: false,
+    stopReason: result.stopReason,
+    invocationState: result.invocationState,
+  };
+}


### PR DESCRIPTION
Adds the bare server-side run primitive the multi-lens content review
engine needs (content-tracking#220): build a Strands Agent, run one turn
to completion, return the answer — no session manager, snapshots, or
DynamoDB, so it needs no table and leaves no trace.

runAgent covers the engine's core asks in one call:
- Structured output enforcement — pass a Zod outputSchema and get the
  validated object back (SDK forces the structured-output tool; a
  resolved call is a schema-valid one), else the response text.
- Bounded tool loops — maxIterations maps to the SDK per-invocation
  limits.turns so a tool-using lens (fact-check over web search) can't
  run away.
- Per-lens model selection — modelId pins a Pro-/Lite-tier model per call.
- Trusted context injection — invocationState is threaded to every tool's
  execution context (context.invocationState) and returned on the result;
  the model can't supply or forge tenantId/sub since it isn't a tool input.

Also re-exports the SDK tool() helper so hosts define tools without
importing the SDK directly. Adds run.test.ts (9 cases) and documents the
primitive plus a multi-lens sketch in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AxtQCsGnfEu8MqjNaLNzD4