### PR TITLE
Ship built-in tools (http_request, notebook) as a reusable toolkit

### DIFF
--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../agent": {
       "name": "@readysetcloud/agent",
-      "version": "0.2.0",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1085.0",

--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -8,6 +8,7 @@ import {
   getSessionConfig,
   resolveTools,
   resolveMcpServerConfigs,
+  builtinTools,
   type ServerMessage,
   type ToolRegistry,
 } from '@readysetcloud/agent';
@@ -103,7 +104,12 @@ const MCP_ALLOWED_HOSTS = (process.env.MCP_ALLOWED_HOSTS ?? '')
 // skipped. Register your own tools here — SELECTING a tool per session is a data
 // operation (no redeploy); only AUTHORING a new one needs a code change. This
 // composes with external MCP tools, which are attached alongside these.
+//
+// `builtinTools` (from @readysetcloud/agent) contributes the shipped generic
+// tools — `http_request` (the web-search / external-API seam) and `notebook` —
+// so a session opts into web search by adding "http_request" to its `tools`.
 const TOOL_REGISTRY: ToolRegistry = {
+  ...builtinTools,
   get_current_time: () =>
     tool({
       name: 'get_current_time',

--- a/agent/README.md
+++ b/agent/README.md
@@ -32,6 +32,7 @@ Strands SDK and `zod`.
 | `handleTask(agent, { request })` | Buffered sibling of `handleUserMessage`: invokes the agent, flushes memory, returns the final text — no streaming. The single-turn primitive `runAgentTask` wraps. |
 | `runAgent({ input, systemPrompt?, modelId?, tools?, outputSchema?, maxIterations?, invocationState?, … })` | Stateless one-shot server-side invocation — build-and-discard, no session/snapshot/table. Enforces a Zod `outputSchema` (returns the validated object), bounds tool loops with `maxIterations`, and injects trusted per-call context via `invocationState`. See [Server-side one-shot runs](#server-side-one-shot-runs-runagent). |
 | `tool({ name, description, inputSchema, callback })` | Re-export of the Strands tool-definition helper, so hosts define tools without importing the SDK directly. Handlers read trusted context from `context.invocationState`. |
+| `builtinTools`, `BUILTIN_TOOL_NAMES`, `httpRequest`, `notebook` | Shipped first-party tools. `builtinTools` is a ready-made registry (`http_request`, `notebook`) a host spreads into its own; the raw instances attach directly to a `tools` list. `http_request` is the web-search / external-API seam. See [Built-in tools](#built-in-tools). |
 | `createTask` / `startTask` / `finishTask` / `getTask`, `requestAgentTask` / `emitTaskCompleted`, `TaskResultCache` | The autonomous-task data plane: durable task rows (idempotent lifecycle), the EventBridge trigger/result contract, and an in-memory result cache. All Strands-free (on `./memory`). |
 | `streamTurn(stream, { sessionId, send })`, `toStreamEventBodies(event)` | Streaming primitives / the SDK→wire normalizer (the one SDK coupling point). |
 | `DynamoSnapshotStorage` | Implements Strands' `SnapshotStorage` port against the single table. |
@@ -326,6 +327,54 @@ for how the runtime resolves specs and forwards verified identity via
 delivery), run the outer call as a task (`runAgentTask`) and let its lenses call
 `runAgent`. Streaming a run's tokens is not covered here — `runAgent` buffers
 the final answer.
+
+## Built-in tools
+
+The package ships a small set of generic, first-party tools so every consumer
+gets common capabilities without re-authoring a wrapper. They're thin factories
+over the Strands SDK's own **vended tools**, so the implementations stay
+maintained and schema-validated upstream:
+
+| Name | What it does |
+| --- | --- |
+| `http_request` | Generic HTTP client (GET/POST/…). The **web-search** seam: point it at a search API and let the model read the JSON back. Also any public REST endpoint or webhook, without a bespoke tool per integration. |
+| `notebook` | An in-invocation scratchpad the model writes to and re-reads across steps of a run. State lives in the invocation, not on the host. |
+
+`builtinTools` is a `ToolRegistry` a host spreads into its own so a session opts
+in **by name**; the raw instances (`httpRequest`, `notebook`) attach directly to
+any `tools` list:
+
+```ts
+import { createAssistant, runAgent, builtinTools, httpRequest, tool } from '@readysetcloud/agent';
+
+// (a) Host registry: session enables it via `tools: ['http_request']` in its config.
+const TOOL_REGISTRY = { ...builtinTools, get_current_time: () => tool({ /* … */ }) };
+
+// (b) Direct attach — e.g. an agent in another repo that just needs web search:
+const res = await runAgent({
+  input: 'What shipped in the latest Strands TS release? Search the web.',
+  systemPrompt: 'Use http_request against https://api.tavily.com/search (Bearer $TAVILY_KEY) to search, then answer.',
+  tools: [httpRequest],
+  maxIterations: 6,
+});
+```
+
+**Web search, concretely.** There is no dedicated search tool in the SDK — the
+model drives `http_request`: it forms the request to a search API (the key rides
+in the URL/headers your prompt or host supplies) and reads the results back. This
+keeps the package provider-neutral; swap Tavily/Brave/Exa/etc. by changing the
+endpoint, no code change here.
+
+**Not exposed: `bash`, `file_editor`.** The SDK also vends these; this package
+deliberately omits them because it's meant to run in a shared, hosted runtime
+where shell exec is remote code execution and filesystem access reaches the
+host's disk. A host that wants them imports them from the SDK and registers them
+itself — an explicit, auditable choice.
+
+**`http_request` is an outbound-request (SSRF) surface** — the model chooses the
+URL. In rsc-core the runtime has no ambient outbound credentials and its network
+egress is the boundary; a host with tighter needs should front it with an
+allowlist or prefer a scoped MCP web-search gateway (below).
 
 ## MCP servers (external tools)
 

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/agent",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1085.0",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Portable, framework-agnostic Node agent core for Ready, Set, Cloud: a Strands-TS assistant with DynamoDB-backed conversation snapshots and pluggable cross-session memory.",
   "author": "allenheltondev",
   "license": "MIT",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -125,6 +125,16 @@ export {
   type AgentTool,
 } from './tools/registry.js';
 
+// Built-in first-party tools shipped with the package (http_request, notebook).
+// `builtinTools` is a ready-made registry a host spreads into its own; the raw
+// tool instances are re-exported for direct attachment to a `tools` list.
+export {
+  builtinTools,
+  BUILTIN_TOOL_NAMES,
+  httpRequest,
+  notebook,
+} from './tools/builtin.js';
+
 // Configuration constants.
 export {
   DEFAULT_MODEL_ID,

--- a/agent/src/tools/builtin.test.ts
+++ b/agent/src/tools/builtin.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  builtinTools,
+  BUILTIN_TOOL_NAMES,
+  httpRequest,
+  notebook,
+} from './builtin.js';
+import { resolveTools, type ToolContext } from './registry.js';
+
+// These wrap the SDK's vended tools, so we don't re-test the tools themselves —
+// we assert the packaging contract: the right names are registered, each factory
+// yields the shared vended instance, and the map drops cleanly into resolveTools.
+describe('builtinTools', () => {
+  const context: ToolContext = { sessionId: 'sess-1', userId: 'user-1' };
+
+  it('registers exactly the safe generic tools by their SDK names', () => {
+    expect(BUILTIN_TOOL_NAMES.sort()).toEqual(['http_request', 'notebook']);
+    // bash / file_editor are intentionally not exposed in a hosted runtime.
+    expect(builtinTools).not.toHaveProperty('bash');
+    expect(builtinTools).not.toHaveProperty('file_editor');
+  });
+
+  it('each factory returns the shared vended tool instance', () => {
+    expect(builtinTools.http_request(context)).toBe(httpRequest);
+    expect(builtinTools.notebook(context)).toBe(notebook);
+  });
+
+  it('resolves through the registry resolver like any host-owned tool', () => {
+    const tools = resolveTools(['http_request', 'notebook'], builtinTools, context);
+    expect(tools).toEqual([httpRequest, notebook]);
+  });
+
+  it('re-exports instances that carry their advertised tool names', () => {
+    expect(httpRequest.name).toBe('http_request');
+    expect(notebook.name).toBe('notebook');
+  });
+});

--- a/agent/src/tools/builtin.ts
+++ b/agent/src/tools/builtin.ts
@@ -1,0 +1,82 @@
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request';
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook';
+import type { ToolRegistry } from './registry.js';
+
+// First-party built-in tools that ship WITH this package, ready for any host to
+// offer or any caller to attach. The tool registry itself still lives in the
+// host (see registry.ts) — apps own their menu of tools — but a generic
+// capability like "make an HTTP request" is worth carrying here so every
+// consumer gets it without re-authoring the same wrapper. The other side of the
+// seam is unchanged: a host spreads {@link builtinTools} into its own registry
+// and a session opts in by NAME.
+//
+// These wrap the Strands SDK's own vended tools (`@strands-agents/sdk/vended-tools`)
+// so we get maintained, schema-validated implementations rather than home-grown
+// ones. We deliberately expose only the tools that are safe and meaningful for a
+// multi-tenant, ephemeral, server-side runtime:
+//
+//   - `http_request` — a generic HTTP client (GET/POST/…). This is the seam a
+//     caller uses for WEB SEARCH: point it at a search API's endpoint (the
+//     model supplies the query; the host supplies any key via the URL/headers)
+//     and let the agent read the JSON back. Anything reachable over HTTP — a
+//     search API, a public REST endpoint, a webhook — is in reach without a
+//     bespoke first-party tool per integration.
+//   - `notebook` — a scratchpad the model can write to and re-read within a run,
+//     useful for multi-step reasoning. State lives in the invocation, not on the
+//     host, so it is safe across sessions.
+//
+// The SDK also vends `bash` and `file_editor`. We intentionally DO NOT expose
+// them: this package is meant to run inside a shared, hosted runtime (AgentCore,
+// Lambda), where shell execution is remote code execution and filesystem access
+// reaches the host's own disk. A host that genuinely wants them can still import
+// them from the SDK and register them itself — that stays an explicit, auditable
+// choice rather than a default this package hands out.
+//
+// NOTE ON `http_request` REACH: because the model chooses the URL, this tool is
+// an outbound-request (SSRF) surface. In rsc-core the AgentCore runtime runs
+// with no ambient outbound credentials and the network egress it's given is the
+// boundary; a host with tighter needs should front the call with an allowlist or
+// prefer a scoped MCP web-search gateway (see the README's MCP section) over the
+// raw client.
+
+/**
+ * The vended `http_request` tool: a generic HTTP client the agent can use to
+ * call external APIs — including a web-search API — reading the response body
+ * back into the conversation. Re-exported so callers can attach it directly to
+ * a `runAgent`/`createAssistant` `tools` list without going through a registry.
+ */
+export { httpRequest };
+
+/**
+ * The vended `notebook` tool: an in-invocation scratchpad the model can write to
+ * and re-read across steps of a single run. Re-exported for direct attachment.
+ */
+export { notebook };
+
+/**
+ * The built-in tools this package ships, as a {@link ToolRegistry} keyed by the
+ * stable name a session selects. Spread it into a host's own registry to offer
+ * them alongside host-owned tools:
+ *
+ * ```ts
+ * const TOOL_REGISTRY: ToolRegistry = {
+ *   ...builtinTools,          // http_request, notebook
+ *   get_current_time: () => tool({ ... }),
+ * };
+ * ```
+ *
+ * Each entry is a {@link ToolFactory}. The vended tools are stateless singletons
+ * that ignore per-session context, so the factory just returns the shared
+ * instance — reusing it across sessions is how the SDK intends these to be used.
+ */
+export const builtinTools: ToolRegistry = {
+  http_request: () => httpRequest,
+  notebook: () => notebook,
+};
+
+/**
+ * The names of the tools in {@link builtinTools}. Handy for a host that wants to
+ * advertise the built-ins it offers, or validate a session's selection against
+ * the shipped set.
+ */
+export const BUILTIN_TOOL_NAMES = Object.keys(builtinTools);


### PR DESCRIPTION
The agent package deliberately keeps the tool registry in the host, but
generic capabilities are worth carrying so every consumer gets them
without re-authoring a wrapper. Add a `builtinTools` registry backed by
the Strands SDK's vended tools:

- `http_request` — generic HTTP client; the web-search / external-API
  seam (the model drives it against a search API, keeping the package
  provider-neutral).
- `notebook` — in-invocation scratchpad.

`bash` and `file_editor` are intentionally not exposed: this package
runs in a shared, hosted runtime where shell exec is RCE and filesystem
access reaches the host disk. A host can still register them explicitly.

Export `builtinTools`, `BUILTIN_TOOL_NAMES`, and the raw `httpRequest` /
`notebook` instances from the package root, spread `builtinTools` into
the AgentCore runtime's registry so a session opts into web search via
`tools: ['http_request']`, and document the toolkit + the SSRF caveat.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QWVqQcz8wFGWsJAiTKSAj8