### PR TITLE
Add ecosystem-wide URL shortener with edge redirects and analytics

### DIFF
--- a/.github/workflows/bump-links-version.yaml
+++ b/.github/workflows/bump-links-version.yaml
@@ -1,0 +1,58 @@
+name: Bump Links Package Version
+
+# When a PR changes anything under links/, bump the package patch version once.
+# "Once" works by comparing versions against the base branch: if the PR's
+# version already differs from main's (auto-bumped earlier, or a deliberate
+# manual minor/major bump), nothing happens.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'links/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bump-links-${{ github.head_ref }}
+
+jobs:
+  bump:
+    name: Bump version once per PR
+    runs-on: ubuntu-latest
+    # same-repo PRs only (forks can't be pushed to), and let dependabot
+    # PRs manage themselves
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Bump patch version if the PR hasn't bumped yet
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:links/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || echo "none")
+          HEAD_VERSION=$(node -p "require('./links/package.json').version")
+
+          if [ "$BASE_VERSION" = "none" ]; then
+            echo "links/package.json doesn't exist on ${{ github.base_ref }} yet — keeping the PR's chosen version ($HEAD_VERSION)"
+            exit 0
+          fi
+
+          if [ "$BASE_VERSION" != "$HEAD_VERSION" ]; then
+            echo "Version already bumped this PR ($BASE_VERSION -> $HEAD_VERSION) — skipping"
+            exit 0
+          fi
+
+          cd links
+          npm version patch --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          cd ..
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump @readysetcloud/links to $NEW_VERSION"
+          git push
+          echo "Bumped @readysetcloud/links $BASE_VERSION -> $NEW_VERSION"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       ui: ${{ steps.filter.outputs.ui }}
       agent: ${{ steps.filter.outputs.agent }}
+      links: ${{ steps.filter.outputs.links }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -44,6 +45,9 @@ jobs:
               - '.github/workflows/deploy.yaml'
             agent:
               - 'agent/**'
+              - '.github/workflows/deploy.yaml'
+            links:
+              - 'links/**'
               - '.github/workflows/deploy.yaml'
 
   predeploy-validations:
@@ -179,4 +183,42 @@ jobs:
           else
             npm publish
             echo "Published @readysetcloud/agent@$VERSION"
+          fi
+
+  publish-links:
+    name: Publish links package
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.links == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # npm Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build and test
+        working-directory: links
+        run: |
+          npm ci
+          npm run typecheck
+          npm test
+          npm run build
+
+      # Auth is npm Trusted Publishing (OIDC via id-token: write) — no npm
+      # token secret. The trusted publisher on npmjs.com must point at this
+      # repo + deploy.yaml. Requires a recent npm CLI for OIDC support.
+      - name: Publish @readysetcloud/links to npm
+        working-directory: links
+        run: |
+          npm install -g npm@11
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@readysetcloud/links@$VERSION" version > /dev/null 2>&1; then
+            echo "@readysetcloud/links@$VERSION already on npm — skipping publish"
+          else
+            npm publish
+            echo "Published @readysetcloud/links@$VERSION"
           fi

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       ui: ${{ steps.filter.outputs.ui }}
       agent: ${{ steps.filter.outputs.agent }}
+      links: ${{ steps.filter.outputs.links }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -46,6 +47,9 @@ jobs:
               - '.github/workflows/pull-request.yaml'
             agent:
               - 'agent/**'
+              - '.github/workflows/pull-request.yaml'
+            links:
+              - 'links/**'
               - '.github/workflows/pull-request.yaml'
 
   predeploy-validations:
@@ -132,6 +136,24 @@ jobs:
           node-version: 22
       - name: Install, typecheck, test, build
         working-directory: agent
+        run: |
+          npm ci
+          npm run typecheck
+          npm test
+          npm run build
+
+  validate-links:
+    name: Validate links package
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.actor != 'dependabot[bot]' && needs.changes.outputs.links == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install, typecheck, test, build
+        working-directory: links
         run: |
           npm ci
           npm run typecheck

--- a/README.md
+++ b/README.md
@@ -126,6 +126,55 @@ surface — badges are its first routes, more will live here over time.
 | `GET /badges/catalog` | none | Every earnable badge + the level ladder |
 | `POST /badges/activity` | Cognito JWT | Record activity for the caller |
 
+## Link shortening — short links, redirects & campaigns
+
+A reusable, ecosystem-wide URL shortener. Any app mints a 6-char code for a
+destination URL, visitors hit `https://<base>/<code>` and are 302'd **at the
+CloudFront edge** (no Lambda in the hot path), codes can be grouped into
+campaigns, and every redirect rolls up into per-code and per-campaign click
+analytics. Expired codes are swept daily.
+
+> **Full guide:** [`functions/LINKS.md`](functions/LINKS.md) — data model,
+> routes, the edge redirect + click pipeline, and the SSM contract.
+> **Client:** [`@readysetcloud/links`](links/README.md).
+
+### How it works
+
+1. **Mint.** A backend calls `createShortLink({ url, campaignId })` from
+   `@readysetcloud/links` (or `POST /links` directly). Core stores the metadata
+   in `LinksTable` and writes the `code → url` mapping into a CloudFront Key
+   Value Store.
+2. **Redirect.** A visitor hits `https://<base>/<code>`. A CloudFront Function
+   looks the code up in the KVS and 302s to the destination, logging a compact
+   `{ code, u, src, ip, s }` line — all at the edge.
+3. **Count.** A CloudWatch Logs subscription fans those lines to
+   `ProcessLinkClick`, which records a click event and upserts the per-code
+   aggregate.
+4. **Read.** `GET /links/{code}/analytics` and
+   `GET /campaigns/{campaignId}/links/analytics` return totals, by-day, and
+   by-source breakdowns.
+
+### API (`LinksApi`, IAM-authed service-to-service)
+
+The management routes are served by a dedicated REST API whose default
+authorizer is **`AWS_IAM`** — a backend signs requests with SigV4 (the
+`@readysetcloud/links` client does this for you; grant its role
+`execute-api:Invoke`). The public redirect is a separate CloudFront
+distribution, not this API.
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /links` | Mint a code (`url`, optional `src`, `campaignId`, `expiresInDays`) |
+| `GET /links/{code}` | Fetch a link's metadata |
+| `PUT /links/{code}` | Repoint a code at a new URL |
+| `DELETE /links/{code}` | Remove the code (metadata, clicks, edge entry) |
+| `GET /links/{code}/analytics` | Per-code click aggregate |
+| `GET /campaigns/{campaignId}/links/analytics` | Every link in a campaign + its clicks |
+
+The base URLs are published to SSM: `/readysetcloud/links/short-link-base`
+(append `/{code}`) and `/readysetcloud/links/api-base-url` (what the client
+signs against).
+
 ## Agent service — streaming AI chat
 
 A Strands-TS assistant ([`@readysetcloud/agent`](agent/README.md)) hosted in

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,12 +10,13 @@ export default [
         process: 'readonly',
         console: 'readonly',
         fetch: 'readonly',
+        Response: 'readonly',
         Buffer: 'readonly',
         TextEncoder: 'readonly',
         URL: 'readonly'
       }
     }
   },
-  { ignores: ['.aws-sam/*', 'ui/dist/*', 'ui/node_modules/*', 'ui/tailwind-preset.cjs', 'agent/dist/*', 'agent/node_modules/*', 'agent-runtime/dist/*', 'agent-runtime/node_modules/*', 'agent-runtime/.artifact/*'] },
+  { ignores: ['.aws-sam/*', 'ui/dist/*', 'ui/node_modules/*', 'ui/tailwind-preset.cjs', 'agent/dist/*', 'agent/node_modules/*', 'agent-runtime/dist/*', 'agent-runtime/node_modules/*', 'agent-runtime/.artifact/*', 'links/dist/*', 'links/node_modules/*'] },
   pluginJs.configs.recommended
 ];

--- a/functions/LINKS.md
+++ b/functions/LINKS.md
@@ -1,0 +1,108 @@
+# Link shortening — short links, redirects & campaigns
+
+A reusable, ecosystem-wide URL shortener living in rsc-core. Any RSC app can mint
+a short code for a destination URL, serve a fast edge redirect from it, group
+codes into campaigns, and read per-code / per-campaign click analytics. Expired
+codes are swept automatically.
+
+This is the backend + infrastructure guide. For the programmatic client, see
+[`@readysetcloud/links`](../links/README.md).
+
+## Shape of it
+
+```
+mint (IAM API)          redirect (public edge)         analytics
+──────────────          ──────────────────────         ─────────
+@readysetcloud/links →  https://<base>/<code>          GET /links/{code}/analytics
+  POST /links              │ CloudFront Function          (per-code aggregate)
+  writes:                  │  • KVS lookup code→url      GET /campaigns/{id}/links/analytics
+   • DynamoDB METADATA     │  • 302 to destination         (rolled up across a campaign)
+   • CloudFront KVS entry  │  • logs {code,u,src,ip,s}
+                           ▼
+                    CloudWatch Logs subscription
+                           ▼
+                    ProcessLinkClick  →  CLICK# events + AGGREGATE upsert
+```
+
+The redirect runs entirely at the CloudFront edge (a CloudFront Function reading
+a Key Value Store) — **no Lambda in the hot path**. Every hit is logged as a
+compact JSON line; a subscription filter fans those logs to `ProcessLinkClick`,
+which records the click and rolls up the aggregate. `SweepExpiredLinks` deletes
+codes past their `expiresAt` daily.
+
+## Data model (`LinksTable`)
+
+A dedicated table (like `AgentChatTable`), keyed by short code:
+
+| pk | sk | entity | purpose |
+| --- | --- | --- | --- |
+| `LINK#{code}` | `METADATA` | `ShortLink` | url, src, campaignId, created/updated/expiresAt |
+| `LINK#{code}` | `AGGREGATE` | `ShortLinkAggregate` | totalClicks, byDay{}, bySrc{}, first/lastClickAt |
+| `LINK#{code}` | `CLICK#{ts}#{ulid}` | `ShortLinkClick` | one click event (TTL 90 days) |
+
+Two GSIs (created with the table, no phased rollout needed):
+
+- **GSI1** — expiry sweep. `GSI1PK = LINK_EXPIRY`, `GSI1SK = {expiresAt ISO}`.
+  `SweepExpiredLinks` queries `GSI1SK < now`.
+- **GSI2** — campaign grouping. `GSI2PK = LINK_CAMPAIGN#{campaignId}`,
+  `GSI2SK = LINK#{createdAt}#{code}`. Written only when a link has a `campaignId`.
+
+`code` is 6 chars of `[A-Za-z0-9]`, allocated with a conditional put and up to 5
+collision retries.
+
+## Management API (`LinksApi`)
+
+A dedicated REST API with **`DefaultAuthorizer: AWS_IAM`** — service-to-service,
+signed with SigV4. One mono-Lambda (`manage-links.mjs`) handles every route via
+the Powertools [event handler](https://docs.aws.amazon.com/powertools/typescript/latest/features/event-handler/rest/)
+`Router`; the API is wired as a single `ANY /{proxy+}` catch-all.
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /links` | Mint a code for a URL (`url`, optional `src`, `campaignId`, `expiresInDays`) |
+| `GET /links/{code}` | Fetch a link's metadata |
+| `PUT /links/{code}` | Repoint a code at a new URL (updates KVS too) |
+| `DELETE /links/{code}` | Remove the code (metadata, clicks, and KVS entry) |
+| `GET /links/{code}/analytics` | Per-code click aggregate |
+| `GET /campaigns/{campaignId}/links/analytics` | Every link in a campaign + its clicks |
+
+Validation errors surface as Powertools `HttpError`s (`{ statusCode, error,
+message }`): 400 for bad input, 404 for a missing code, 503 if a unique code
+can't be allocated.
+
+## Edge redirect
+
+- **`LinkKeyValueStore`** maps `code → { u: destinationUrl, src? }`.
+- **`LinkRedirectFunction`** (CloudFront Function, `cloudfront-js-2.0`) reads the
+  last path segment, looks it up, and 302s to the destination with `no-store`.
+  It guards against redirect loops back to the tracker host, over-long URLs, and
+  non-http(s) destinations, and falls back to `LinkRedirectFallbackUrl` (with a
+  `?reason=` tag) on any miss.
+- **`LinkRedirectDistribution`** fronts it. Set the `LinkRedirectDomain`
+  parameter (with `HostedZoneId`) for a custom short domain — otherwise short
+  URLs use the generated CloudFront domain. Short URLs are root-level:
+  `https://<base>/<code>`.
+
+## Cross-service contract (SSM)
+
+| Parameter | Value |
+| --- | --- |
+| `/readysetcloud/links/short-link-base` | Base URL for short links (append `/{code}`) |
+| `/readysetcloud/links/api-base-url` | IAM-authed management API base (what `@readysetcloud/links` signs against) |
+
+## Consuming from another app
+
+1. Grant the calling Lambda role `execute-api:Invoke` on the `LinksApi`.
+2. `npm i @readysetcloud/links` and call `createShortLink({ url, campaignId })` —
+   it resolves the API URL from SSM (or `LINKS_API_URL`) and signs with the
+   ambient credentials. See the [package README](../links/README.md).
+
+## Pieces
+
+| Piece | Where |
+| --- | --- |
+| Management mono-Lambda (all `/links` + `/campaigns/.../analytics` routes) | [`manage-links.mjs`](manage-links.mjs) |
+| Edge click processor (CloudWatch Logs → analytics) | [`process-link-click.mjs`](process-link-click.mjs) |
+| Daily expiry sweep | [`sweep-expired-links.mjs`](sweep-expired-links.mjs) |
+| Table, KVS, redirect function + distribution, API, SSM | [`template.yaml`](../template.yaml) |
+| Node client | [`@readysetcloud/links`](../links/) |

--- a/functions/__tests__/manage-links.test.mjs
+++ b/functions/__tests__/manage-links.test.mjs
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { marshall } from '@aws-sdk/util-dynamodb';
+
+const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb');
+const { CloudFrontKeyValueStoreClient } = await import('@aws-sdk/client-cloudfront-keyvaluestore');
+
+process.env.TABLE_NAME = 'test-links-table';
+process.env.KVS_ARN = 'arn:aws:cloudfront::123456789012:key-value-store/abc';
+process.env.SHORT_LINK_BASE = 'https://rdyset.click';
+
+const { handler } = await import('../manage-links.mjs');
+
+const context = { awsRequestId: 'test', functionName: 'ManageLinks' };
+
+// Minimal API Gateway REST (v1) proxy event, matching Powertools' event detector.
+const event = (method, path, { body, query } = {}) => ({
+  resource: '/{proxy+}',
+  httpMethod: method,
+  path,
+  headers: { 'content-type': 'application/json', host: 'links.example.com' },
+  multiValueHeaders: null,
+  requestContext: { httpMethod: method, path, stage: 'Prod' },
+  pathParameters: { proxy: path.replace(/^\//, '') },
+  stageVariables: null,
+  queryStringParameters: query || null,
+  multiValueQueryStringParameters: null,
+  body: body === undefined ? null : typeof body === 'string' ? body : JSON.stringify(body),
+  isBase64Encoded: false,
+});
+
+const invoke = async (...args) => {
+  const res = await handler(event(...args), context);
+  return { statusCode: res.statusCode, body: res.body ? JSON.parse(res.body) : undefined };
+};
+
+let mockDdbSend;
+let mockKvsSend;
+
+beforeEach(() => {
+  mockDdbSend = vi.fn();
+  mockKvsSend = vi.fn().mockResolvedValue({ ETag: 'etag-1' });
+  DynamoDBClient.prototype.send = mockDdbSend;
+  CloudFrontKeyValueStoreClient.prototype.send = mockKvsSend;
+});
+
+const cmd = (call) => call.constructor.name;
+
+describe('POST /links (mint)', () => {
+  test('400 when body missing', async () => {
+    const res = await invoke('POST', '/links');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/Missing request body/);
+  });
+
+  test('400 when url missing', async () => {
+    const res = await invoke('POST', '/links', { body: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/url/);
+  });
+
+  test('400 when url not http(s)', async () => {
+    const res = await invoke('POST', '/links', { body: { url: 'ftp://x.com' } });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when expiresInDays out of range', async () => {
+    const res = await invoke('POST', '/links', { body: { url: 'https://x.com', expiresInDays: 99999 } });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('201 mints a code, writes DDB + KVS', async () => {
+    mockDdbSend.mockResolvedValueOnce({}); // PutItem success
+    const res = await invoke('POST', '/links', { body: { url: 'https://example.com', src: 'nl', campaignId: 'launch' } });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.code).toMatch(/^[A-Za-z0-9]{6}$/);
+    expect(res.body.short_url).toBe(`https://rdyset.click/${res.body.code}`);
+    expect(res.body.expires_at).toBeTruthy();
+
+    const put = mockDdbSend.mock.calls.find((c) => cmd(c[0]) === 'PutItemCommand')[0];
+    expect(put.input.ConditionExpression).toMatch(/attribute_not_exists/);
+    // KVS: Describe then PutKey
+    expect(mockKvsSend.mock.calls.map((c) => cmd(c[0]))).toContain('PutKeyCommand');
+  });
+
+  test('503 when code cannot be allocated after retries', async () => {
+    const err = new Error('exists');
+    err.name = 'ConditionalCheckFailedException';
+    mockDdbSend.mockRejectedValue(err);
+    const res = await invoke('POST', '/links', { body: { url: 'https://example.com' } });
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('GET /links/{code}', () => {
+  test('400 on bad code', async () => {
+    const res = await invoke('GET', '/links/short');
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 when not found', async () => {
+    mockDdbSend.mockResolvedValueOnce({}); // GetItem no Item
+    const res = await invoke('GET', '/links/aB3xY9');
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('200 returns metadata', async () => {
+    mockDdbSend.mockResolvedValueOnce({
+      Item: marshall({
+        code: 'aB3xY9', url: 'https://example.com', src: 'nl', campaignId: 'launch',
+        createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', expiresAt: '2028-01-01T00:00:00.000Z',
+      }),
+    });
+    const res = await invoke('GET', '/links/aB3xY9');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ code: 'aB3xY9', url: 'https://example.com', campaign_id: 'launch' });
+    expect(res.body.short_url).toBe('https://rdyset.click/aB3xY9');
+  });
+});
+
+describe('PUT /links/{code}', () => {
+  test('404 when code does not exist', async () => {
+    const err = new Error('nope');
+    err.name = 'ConditionalCheckFailedException';
+    mockDdbSend.mockRejectedValueOnce(err);
+    const res = await invoke('PUT', '/links/aB3xY9', { body: { url: 'https://new.com' } });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('200 updates destination + KVS', async () => {
+    mockDdbSend.mockResolvedValueOnce({
+      Attributes: marshall({ code: 'aB3xY9', url: 'https://new.com', createdAt: 'c', updatedAt: 'u', expiresAt: 'e' }),
+    });
+    const res = await invoke('PUT', '/links/aB3xY9', { body: { url: 'https://new.com' } });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.url).toBe('https://new.com');
+    expect(mockKvsSend.mock.calls.map((c) => cmd(c[0]))).toContain('PutKeyCommand');
+  });
+});
+
+describe('DELETE /links/{code}', () => {
+  test('204 deletes KVS key + DDB partition', async () => {
+    // deleteKvsKey: Describe + DeleteKey ; deletePartition: Query (empty)
+    mockDdbSend.mockResolvedValueOnce({ Items: [] });
+    const res = await invoke('DELETE', '/links/aB3xY9');
+    expect(res.statusCode).toBe(204);
+    expect(mockKvsSend.mock.calls.map((c) => cmd(c[0]))).toContain('DeleteKeyCommand');
+  });
+});
+
+describe('GET /links/{code}/analytics', () => {
+  test('empty analytics when no aggregate', async () => {
+    mockDdbSend.mockResolvedValueOnce({}); // GetItem AGGREGATE missing
+    const res = await invoke('GET', '/links/aB3xY9/analytics');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ code: 'aB3xY9', total_clicks: 0, by_day: {}, by_src: {} });
+  });
+
+  test('returns aggregate', async () => {
+    mockDdbSend.mockResolvedValueOnce({
+      Item: marshall({ code: 'aB3xY9', totalClicks: 3, byDay: { '2026-07-20': 3 }, bySrc: { web: 3 }, firstClickAt: 'f', lastClickAt: 'l' }),
+    });
+    const res = await invoke('GET', '/links/aB3xY9/analytics');
+    expect(res.body.total_clicks).toBe(3);
+    expect(res.body.by_src).toEqual({ web: 3 });
+  });
+});
+
+describe('GET /campaigns/{campaignId}/links/analytics', () => {
+  test('aggregates links + clicks for a campaign', async () => {
+    // 1) Query GSI2 -> one link ; 2) BatchGet aggregates
+    mockDdbSend.mockResolvedValueOnce({
+      Items: [marshall({ code: 'aB3xY9', url: 'https://example.com', campaignId: 'launch', createdAt: 'c', updatedAt: 'u', expiresAt: 'e' })],
+    });
+    mockDdbSend.mockResolvedValueOnce({
+      Responses: { 'test-links-table': [marshall({ code: 'aB3xY9', totalClicks: 7, byDay: {}, bySrc: {} })] },
+    });
+    const res = await invoke('GET', '/campaigns/launch/links/analytics');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ campaign_id: 'launch', total_links: 1, total_clicks: 7 });
+    expect(res.body.links[0].analytics.total_clicks).toBe(7);
+  });
+});
+
+describe('unknown route', () => {
+  test('404', async () => {
+    const res = await invoke('GET', '/nope');
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/functions/__tests__/process-link-click.test.mjs
+++ b/functions/__tests__/process-link-click.test.mjs
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import zlib from 'zlib';
+
+const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb');
+
+process.env.TABLE_NAME = 'test-links-table';
+
+const { handler } = await import('../process-link-click.mjs');
+
+const logsEvent = (messages) => {
+  const payload = {
+    logGroup: '/aws/cloudfront/function/rsc-link-redirect',
+    logStream: 'stream',
+    logEvents: messages.map((m, i) => ({
+      id: String(i),
+      timestamp: Date.parse('2026-07-20T12:00:00Z'),
+      message: typeof m === 'string' ? m : JSON.stringify(m),
+    })),
+  };
+  return { awslogs: { data: zlib.gzipSync(Buffer.from(JSON.stringify(payload))).toString('base64') } };
+};
+
+let mockDdbSend;
+beforeEach(() => {
+  mockDdbSend = vi.fn().mockResolvedValue({});
+  DynamoDBClient.prototype.send = mockDdbSend;
+});
+
+const cmd = (call) => call[0].constructor.name;
+
+describe('process-link-click', () => {
+  test('records a click event and increments the aggregate', async () => {
+    const res = await handler(logsEvent([{ code: 'aB3xY9', u: 'https://example.com', src: 'nl' }]));
+    expect(res.statusCode).toBe(200);
+
+    const names = mockDdbSend.mock.calls.map(cmd);
+    expect(names).toContain('PutItemCommand');   // click event
+    expect(names).toContain('UpdateItemCommand'); // aggregate
+
+    const put = mockDdbSend.mock.calls.find((c) => cmd(c) === 'PutItemCommand')[0];
+    expect(put.input.Item.pk.S).toBe('LINK#aB3xY9');
+    expect(put.input.Item.sk.S).toMatch(/^CLICK#/);
+  });
+
+  test('skips messages without a code', async () => {
+    await handler(logsEvent([{ u: 'https://example.com' }, 'no json here']));
+    expect(mockDdbSend).not.toHaveBeenCalled();
+  });
+
+  test('tolerates a malformed CloudWatch payload', async () => {
+    const res = await handler({ awslogs: { data: 'not-base64-gzip' } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).processed).toBe(0);
+  });
+});

--- a/functions/__tests__/sweep-expired-links.test.mjs
+++ b/functions/__tests__/sweep-expired-links.test.mjs
@@ -1,0 +1,56 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { marshall } from '@aws-sdk/util-dynamodb';
+
+const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb');
+const { CloudFrontKeyValueStoreClient } = await import('@aws-sdk/client-cloudfront-keyvaluestore');
+
+process.env.TABLE_NAME = 'test-links-table';
+process.env.KVS_ARN = 'arn:aws:cloudfront::123456789012:key-value-store/abc';
+
+const { handler } = await import('../sweep-expired-links.mjs');
+
+let mockDdbSend;
+let mockKvsSend;
+const cmd = (call) => call[0].constructor.name;
+
+beforeEach(() => {
+  mockDdbSend = vi.fn();
+  mockKvsSend = vi.fn().mockResolvedValue({ ETag: 'etag-1' });
+  DynamoDBClient.prototype.send = mockDdbSend;
+  CloudFrontKeyValueStoreClient.prototype.send = mockKvsSend;
+});
+
+describe('sweep-expired-links', () => {
+  test('deletes expired codes from KVS and DynamoDB', async () => {
+    // GSI1 query -> one expired code, then deletePartition Query -> empty
+    mockDdbSend
+      .mockResolvedValueOnce({ Items: [marshall({ code: 'aB3xY9' })] }) // GSI1 expiry query
+      .mockResolvedValueOnce({ Items: [] }); // deletePartition query
+
+    const result = await handler();
+
+    expect(result.deleted).toBe(1);
+    expect(mockKvsSend.mock.calls.map(cmd)).toContain('DeleteKeyCommand');
+  });
+
+  test('counts codes whose KVS key is already gone', async () => {
+    const notFound = new Error('missing');
+    notFound.name = 'ResourceNotFoundException';
+    mockKvsSend
+      .mockResolvedValueOnce({ ETag: 'etag-1' }) // initial Describe
+      .mockRejectedValueOnce(notFound); // DeleteKey -> not found
+    mockDdbSend
+      .mockResolvedValueOnce({ Items: [marshall({ code: 'aB3xY9' })] })
+      .mockResolvedValueOnce({ Items: [] }); // deletePartition still runs
+
+    const result = await handler();
+    expect(result.kvsMissing).toBe(1);
+    expect(result.deleted).toBe(0);
+  });
+
+  test('no expired codes is a no-op', async () => {
+    mockDdbSend.mockResolvedValueOnce({ Items: [] });
+    const result = await handler();
+    expect(result).toEqual({ deleted: 0, kvsMissing: 0, failed: 0 });
+  });
+});

--- a/functions/manage-links.mjs
+++ b/functions/manage-links.mjs
@@ -1,0 +1,404 @@
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  GetItemCommand,
+  UpdateItemCommand,
+  QueryCommand,
+  BatchWriteItemCommand,
+  BatchGetItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import '@aws-sdk/signature-v4a';
+import {
+  CloudFrontKeyValueStoreClient,
+  DescribeKeyValueStoreCommand,
+  PutKeyCommand,
+  DeleteKeyCommand,
+} from '@aws-sdk/client-cloudfront-keyvaluestore';
+import {
+  Router,
+  BadRequestError,
+  NotFoundError,
+  ServiceUnavailableError,
+} from '@aws-lambda-powertools/event-handler/http';
+import crypto from 'crypto';
+
+const ddb = new DynamoDBClient();
+const kvs = new CloudFrontKeyValueStoreClient();
+const app = new Router();
+
+const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const CODE_LENGTH = 6;
+const CODE_PATTERN = /^[A-Za-z0-9]{6}$/;
+const MAX_COLLISION_RETRIES = 5;
+const DEFAULT_EXPIRES_IN_DAYS = 730;
+const MAX_EXPIRES_IN_DAYS = 1825;
+const MAX_CAMPAIGN_ID_LENGTH = 128;
+
+// ---------------------------------------------------------------------------
+// Routes — one Lambda, Powertools routing. All routes are IAM-authorized at
+// the API (service-to-service); the public redirect lives at the CloudFront
+// edge, not here.
+// ---------------------------------------------------------------------------
+app.post('/links', mintLink);
+app.get('/links/:code', getLink);
+app.put('/links/:code', updateLink);
+app.delete('/links/:code', deleteLink);
+app.get('/links/:code/analytics', getLinkAnalytics);
+app.get('/campaigns/:campaignId/links/analytics', getCampaignLinksAnalytics);
+
+export const handler = async (event, context) => app.resolve(event, context);
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+async function mintLink(reqCtx) {
+  const body = await readJsonBody(reqCtx);
+  const { url, src, expiresInDays, campaignId } = body;
+
+  validateUrl(url);
+  if (src !== undefined && typeof src !== 'string') {
+    throw new BadRequestError('src must be a string when provided');
+  }
+  if (campaignId !== undefined) {
+    if (typeof campaignId !== 'string') throw new BadRequestError('campaignId must be a string when provided');
+    if (campaignId.trim().length === 0) throw new BadRequestError('campaignId cannot be empty when provided');
+    if (campaignId.length > MAX_CAMPAIGN_ID_LENGTH) throw new BadRequestError(`campaignId exceeds ${MAX_CAMPAIGN_ID_LENGTH} chars`);
+  }
+  if (expiresInDays !== undefined &&
+    (!Number.isInteger(expiresInDays) || expiresInDays < 1 || expiresInDays > MAX_EXPIRES_IN_DAYS)) {
+    throw new BadRequestError(`expiresInDays must be an integer between 1 and ${MAX_EXPIRES_IN_DAYS}`);
+  }
+
+  const ttlDays = expiresInDays ?? DEFAULT_EXPIRES_IN_DAYS;
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + ttlDays * 86400 * 1000).toISOString();
+
+  const code = await allocateUniqueCode(now.toISOString(), expiresAt, url, src, campaignId);
+  if (!code) {
+    throw new ServiceUnavailableError('Could not allocate a unique code');
+  }
+
+  const kvsValue = { u: url };
+  if (src) kvsValue.src = src;
+  await writeKvsEntry(code, kvsValue);
+
+  return created({
+    code,
+    short_url: `${process.env.SHORT_LINK_BASE}/${code}`,
+    expires_at: expiresAt,
+  });
+}
+
+async function getLink(reqCtx) {
+  const code = validateCode(reqCtx.params.code);
+
+  const result = await ddb.send(new GetItemCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: marshall({ pk: `LINK#${code}`, sk: 'METADATA' }),
+  }));
+
+  if (!result.Item) {
+    throw new NotFoundError(`Code ${code} not found`);
+  }
+
+  return formatLink(unmarshall(result.Item));
+}
+
+async function updateLink(reqCtx) {
+  const code = validateCode(reqCtx.params.code);
+  const body = await readJsonBody(reqCtx);
+  const { url, src } = body;
+
+  validateUrl(url);
+  if (src !== undefined && src !== null && typeof src !== 'string') {
+    throw new BadRequestError('src must be a string when provided');
+  }
+
+  const updatedAt = new Date().toISOString();
+  let updated;
+  try {
+    const result = await ddb.send(new UpdateItemCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: marshall({ pk: `LINK#${code}`, sk: 'METADATA' }),
+      UpdateExpression: 'SET #url = :url, src = :src, updatedAt = :updatedAt',
+      ConditionExpression: 'attribute_exists(pk)',
+      ExpressionAttributeNames: { '#url': 'url' },
+      ExpressionAttributeValues: marshall({
+        ':url': url,
+        ':src': src ?? null,
+        ':updatedAt': updatedAt,
+      }),
+      ReturnValues: 'ALL_NEW',
+    }));
+    updated = unmarshall(result.Attributes);
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      throw new NotFoundError(`Code ${code} not found`);
+    }
+    throw err;
+  }
+
+  const kvsValue = { u: url };
+  if (src) kvsValue.src = src;
+  await writeKvsEntry(code, kvsValue);
+
+  return formatLink(updated);
+}
+
+async function deleteLink(reqCtx) {
+  const code = validateCode(reqCtx.params.code);
+
+  await deleteKvsKey(code);
+  await deletePartition(`LINK#${code}`);
+
+  return noContent();
+}
+
+async function getLinkAnalytics(reqCtx) {
+  const code = validateCode(reqCtx.params.code);
+
+  const result = await ddb.send(new GetItemCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: marshall({ pk: `LINK#${code}`, sk: 'AGGREGATE' }),
+  }));
+
+  if (!result.Item) {
+    return emptyAnalytics(code);
+  }
+
+  return formatAnalytics(code, unmarshall(result.Item));
+}
+
+async function getCampaignLinksAnalytics(reqCtx) {
+  const campaignId = reqCtx.params.campaignId;
+  if (!campaignId || typeof campaignId !== 'string' || campaignId.trim().length === 0) {
+    throw new BadRequestError('campaignId is required');
+  }
+  if (campaignId.length > MAX_CAMPAIGN_ID_LENGTH) {
+    throw new BadRequestError(`campaignId exceeds ${MAX_CAMPAIGN_ID_LENGTH} chars`);
+  }
+
+  const links = await queryCampaignLinks(campaignId);
+  const analyticsByCode = await batchGetAnalytics(links.map((link) => link.code));
+
+  return {
+    campaign_id: campaignId,
+    total_links: links.length,
+    total_clicks: links.reduce((sum, link) => sum + (analyticsByCode.get(link.code)?.total_clicks ?? 0), 0),
+    links: links.map((link) => ({
+      ...formatLink(link),
+      analytics: analyticsByCode.get(link.code) ?? emptyAnalytics(link.code),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validation + response helpers
+// ---------------------------------------------------------------------------
+function validateUrl(url) {
+  if (!url || typeof url !== 'string') throw new BadRequestError('url is required');
+  if (!/^https?:\/\//i.test(url)) throw new BadRequestError('url must be http or https');
+  if (url.length > 2048) throw new BadRequestError('url exceeds 2048 chars');
+}
+
+function validateCode(code) {
+  if (!code || !CODE_PATTERN.test(code)) {
+    throw new BadRequestError('code must be 6 alphanumeric characters');
+  }
+  return code;
+}
+
+async function readJsonBody(reqCtx) {
+  const raw = await reqCtx.req.text();
+  if (!raw) throw new BadRequestError('Missing request body');
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new BadRequestError('Invalid JSON body');
+  }
+}
+
+const jsonHeaders = { 'content-type': 'application/json' };
+const created = (body) => new Response(JSON.stringify(body), { status: 201, headers: jsonHeaders });
+const noContent = () => new Response(null, { status: 204 });
+
+function formatLink(row) {
+  return {
+    code: row.code,
+    short_url: `${process.env.SHORT_LINK_BASE}/${row.code}`,
+    url: row.url,
+    src: row.src ?? null,
+    campaign_id: row.campaignId ?? null,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+    expires_at: row.expiresAt,
+  };
+}
+
+function formatAnalytics(code, row) {
+  return {
+    code,
+    total_clicks: row.totalClicks ?? 0,
+    by_day: row.byDay ?? {},
+    by_src: row.bySrc ?? {},
+    first_click_at: row.firstClickAt ?? null,
+    last_click_at: row.lastClickAt ?? null,
+  };
+}
+
+const emptyAnalytics = (code) => formatAnalytics(code, {});
+
+// ---------------------------------------------------------------------------
+// DynamoDB + CloudFront KVS
+// ---------------------------------------------------------------------------
+async function allocateUniqueCode(createdAt, expiresAt, url, src, campaignId) {
+  for (let attempt = 0; attempt < MAX_COLLISION_RETRIES; attempt++) {
+    const code = generateCode();
+    const item = {
+      pk: `LINK#${code}`,
+      sk: 'METADATA',
+      GSI1PK: 'LINK_EXPIRY',
+      GSI1SK: expiresAt,
+      entity: 'ShortLink',
+      code,
+      url,
+      src: src || null,
+      campaignId: campaignId ?? null,
+      createdAt,
+      expiresAt,
+      updatedAt: createdAt,
+    };
+
+    if (campaignId) {
+      item.GSI2PK = `LINK_CAMPAIGN#${campaignId}`;
+      item.GSI2SK = `LINK#${createdAt}#${code}`;
+    }
+
+    try {
+      await ddb.send(new PutItemCommand({
+        TableName: process.env.TABLE_NAME,
+        Item: marshall(item, { removeUndefinedValues: true }),
+        ConditionExpression: 'attribute_not_exists(pk)',
+      }));
+      return code;
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') continue;
+      throw err;
+    }
+  }
+  return null;
+}
+
+function generateCode() {
+  const bytes = crypto.randomBytes(CODE_LENGTH);
+  let out = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    out += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length];
+  }
+  return out;
+}
+
+async function queryCampaignLinks(campaignId) {
+  const links = [];
+  let exclusiveStartKey;
+
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      IndexName: 'GSI2',
+      KeyConditionExpression: 'GSI2PK = :campaign',
+      ExpressionAttributeValues: marshall({
+        ':campaign': `LINK_CAMPAIGN#${campaignId}`,
+      }),
+      ExclusiveStartKey: exclusiveStartKey,
+    }));
+
+    links.push(...(result.Items || []).map((item) => unmarshall(item)));
+    exclusiveStartKey = result.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return links;
+}
+
+async function batchGetAnalytics(codes) {
+  const analyticsByCode = new Map();
+
+  for (let i = 0; i < codes.length; i += 100) {
+    const keys = codes.slice(i, i + 100).map((code) => marshall({
+      pk: `LINK#${code}`,
+      sk: 'AGGREGATE',
+    }));
+
+    if (keys.length === 0) continue;
+    let requestItems = {
+      [process.env.TABLE_NAME]: { Keys: keys },
+    };
+
+    do {
+      const result = await ddb.send(new BatchGetItemCommand({ RequestItems: requestItems }));
+      for (const item of result.Responses?.[process.env.TABLE_NAME] || []) {
+        const row = unmarshall(item);
+        analyticsByCode.set(row.code, formatAnalytics(row.code, row));
+      }
+      requestItems = result.UnprocessedKeys && Object.keys(result.UnprocessedKeys).length > 0
+        ? result.UnprocessedKeys
+        : null;
+    } while (requestItems);
+  }
+
+  return analyticsByCode;
+}
+
+async function deletePartition(pk) {
+  let lastEvaluatedKey;
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: marshall({ ':pk': pk }),
+      ProjectionExpression: '#pk, sk',
+      ExclusiveStartKey: lastEvaluatedKey,
+    }));
+
+    const items = result.Items || [];
+    for (let i = 0; i < items.length; i += 25) {
+      const batch = items.slice(i, i + 25).map((it) => {
+        const row = unmarshall(it);
+        return { DeleteRequest: { Key: marshall({ pk: row.pk, sk: row.sk }) } };
+      });
+      if (batch.length === 0) continue;
+      await ddb.send(new BatchWriteItemCommand({
+        RequestItems: { [process.env.TABLE_NAME]: batch },
+      }));
+    }
+    lastEvaluatedKey = result.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+}
+
+async function writeKvsEntry(code, value) {
+  const describe = await kvs.send(new DescribeKeyValueStoreCommand({ KvsARN: process.env.KVS_ARN }));
+  await kvs.send(new PutKeyCommand({
+    KvsARN: process.env.KVS_ARN,
+    Key: code,
+    Value: JSON.stringify(value),
+    IfMatch: describe.ETag,
+  }));
+}
+
+async function deleteKvsKey(code) {
+  const describe = await kvs.send(new DescribeKeyValueStoreCommand({ KvsARN: process.env.KVS_ARN }));
+  try {
+    await kvs.send(new DeleteKeyCommand({
+      KvsARN: process.env.KVS_ARN,
+      Key: code,
+      IfMatch: describe.ETag,
+    }));
+  } catch (err) {
+    if (err.name === 'ResourceNotFoundException' || err.$metadata?.httpStatusCode === 404) {
+      return;
+    }
+    throw err;
+  }
+}

--- a/functions/process-link-click.mjs
+++ b/functions/process-link-click.mjs
@@ -1,0 +1,141 @@
+import { DynamoDBClient, UpdateItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { ulid } from 'ulid';
+import zlib from 'zlib';
+
+const ddb = new DynamoDBClient();
+const TABLE = process.env.TABLE_NAME;
+const CONCURRENCY = parseInt(process.env.MAX_CONCURRENCY || '25', 10);
+const CLICK_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+// Consumes the short-link redirect CloudFront Function logs (delivered via a
+// CloudWatch Logs subscription filter). Each redirect logs a JSON line
+// { code, u, src, ip, s }; this records a per-click event and rolls up an
+// aggregate per code.
+export const handler = async (event) => {
+  let data;
+  try {
+    data = decodeLogs(event);
+  } catch (err) {
+    console.error('Failed to decode CloudWatch Logs payload', err);
+    return { statusCode: 200, body: JSON.stringify({ processed: 0 }) };
+  }
+
+  const events = data.logEvents || [];
+  if (!events.length) {
+    return { statusCode: 200, body: JSON.stringify({ processed: 0 }) };
+  }
+
+  const ops = [];
+  for (const e of events) {
+    const json = extractJson(e.message);
+    if (!json) continue;
+
+    let msg;
+    try {
+      msg = JSON.parse(json);
+    } catch {
+      continue;
+    }
+
+    if (!msg || typeof msg !== 'object') continue;
+    if (!msg.code || typeof msg.code !== 'string') continue;
+
+    const occurredAt = new Date(e.timestamp || Date.now()).toISOString();
+    const day = occurredAt.slice(0, 10);
+    const src = msg.src || 'web';
+
+    ops.push(() => recordClickEvent({ code: msg.code, occurredAt, src, raw: msg }));
+    ops.push(() => incrementAggregate({ code: msg.code, day, src, occurredAt }));
+  }
+
+  const results = await runInBatches(ops, CONCURRENCY);
+  const failures = results.filter((r) => r.status === 'rejected');
+  if (failures.length) {
+    console.error(`Failed ops: ${failures.length}`, failures.slice(0, 3));
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      processed: results.length - failures.length,
+      failed: failures.length,
+    }),
+  };
+};
+
+async function recordClickEvent({ code, occurredAt, src, raw }) {
+  await ddb.send(new PutItemCommand({
+    TableName: TABLE,
+    Item: marshall({
+      pk: `LINK#${code}`,
+      sk: `CLICK#${occurredAt}#${ulid()}`,
+      entity: 'ShortLinkClick',
+      code,
+      occurredAt,
+      src,
+      destinationUrl: raw.u || null,
+      subscriberHash: raw.s || null,
+      ttl: Math.floor(Date.now() / 1000) + CLICK_TTL_SECONDS,
+    }, { removeUndefinedValues: true }),
+  }));
+}
+
+async function incrementAggregate({ code, day, src, occurredAt }) {
+  try {
+    await ddb.send(new UpdateItemCommand({
+      TableName: TABLE,
+      Key: marshall({ pk: `LINK#${code}`, sk: 'AGGREGATE' }),
+      UpdateExpression: [
+        'SET code = if_not_exists(code, :code)',
+        'entity = if_not_exists(entity, :entity)',
+        'byDay.#day = if_not_exists(byDay.#day, :zero) + :one',
+        'bySrc.#src = if_not_exists(bySrc.#src, :zero) + :one',
+        'lastClickAt = :ts',
+        'firstClickAt = if_not_exists(firstClickAt, :ts)',
+      ].join(', ') + ' ADD totalClicks :one',
+      ExpressionAttributeNames: { '#day': day, '#src': src },
+      ExpressionAttributeValues: marshall({
+        ':code': code,
+        ':entity': 'ShortLinkAggregate',
+        ':zero': 0,
+        ':one': 1,
+        ':ts': occurredAt,
+      }),
+    }));
+  } catch (err) {
+    if (err.name === 'ValidationException') {
+      await ddb.send(new UpdateItemCommand({
+        TableName: TABLE,
+        Key: marshall({ pk: `LINK#${code}`, sk: 'AGGREGATE' }),
+        UpdateExpression: 'SET byDay = if_not_exists(byDay, :empty), bySrc = if_not_exists(bySrc, :empty)',
+        ExpressionAttributeValues: marshall({ ':empty': {} }),
+      }));
+      return incrementAggregate({ code, day, src, occurredAt });
+    }
+    throw err;
+  }
+}
+
+function extractJson(message) {
+  const start = message.indexOf('{');
+  const end = message.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  return message.substring(start, end + 1);
+}
+
+function decodeLogs(event) {
+  const payload = Buffer.from(event.awslogs.data, 'base64');
+  const json = zlib.gunzipSync(payload).toString('utf8');
+  return JSON.parse(json);
+}
+
+async function runInBatches(ops, batchSize) {
+  const results = [];
+  for (let i = 0; i < ops.length; i += batchSize) {
+    const batch = ops.slice(i, i + batchSize);
+    const settled = await Promise.allSettled(batch.map((fn) => fn()));
+    results.push(...settled);
+  }
+  return results;
+}

--- a/functions/sweep-expired-links.mjs
+++ b/functions/sweep-expired-links.mjs
@@ -1,0 +1,119 @@
+import { DynamoDBClient, QueryCommand, BatchWriteItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import '@aws-sdk/signature-v4a';
+import {
+  CloudFrontKeyValueStoreClient,
+  DescribeKeyValueStoreCommand,
+  DeleteKeyCommand,
+} from '@aws-sdk/client-cloudfront-keyvaluestore';
+
+const ddb = new DynamoDBClient();
+const kvs = new CloudFrontKeyValueStoreClient();
+
+const QUERY_LIMIT = 100;
+
+// Scheduled daily. Finds codes whose expiresAt has passed via GSI1 and removes
+// both the DynamoDB partition (metadata + aggregate + clicks) and the KVS key
+// that backs the edge redirect.
+export const handler = async () => {
+  const nowIso = new Date().toISOString();
+  let deleted = 0;
+  let kvsMissing = 0;
+  let failed = 0;
+  let lastEvaluatedKey;
+
+  let etag = await refreshEtag();
+
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :pk AND GSI1SK < :now',
+      ExpressionAttributeValues: marshall({
+        ':pk': 'LINK_EXPIRY',
+        ':now': nowIso,
+      }),
+      Limit: QUERY_LIMIT,
+      ExclusiveStartKey: lastEvaluatedKey,
+    }));
+
+    for (const item of result.Items || []) {
+      const row = unmarshall(item);
+      const code = row.code;
+      if (!code) continue;
+
+      try {
+        etag = await deleteKvsKey(code, etag);
+        await deletePartition(`LINK#${code}`);
+        deleted++;
+      } catch (err) {
+        if (err.name === 'ResourceNotFoundException' || err.$metadata?.httpStatusCode === 404) {
+          await deletePartition(`LINK#${code}`);
+          kvsMissing++;
+        } else {
+          failed++;
+          console.error('Failed to delete expired code', { code, error: err.message, name: err.name });
+        }
+      }
+    }
+
+    lastEvaluatedKey = result.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  console.log('Sweep complete', { deleted, kvsMissing, failed });
+  return { deleted, kvsMissing, failed };
+};
+
+async function refreshEtag() {
+  const describe = await kvs.send(new DescribeKeyValueStoreCommand({ KvsARN: process.env.KVS_ARN }));
+  return describe.ETag;
+}
+
+async function deleteKvsKey(code, currentEtag) {
+  try {
+    const result = await kvs.send(new DeleteKeyCommand({
+      KvsARN: process.env.KVS_ARN,
+      Key: code,
+      IfMatch: currentEtag,
+    }));
+    return result.ETag || currentEtag;
+  } catch (err) {
+    if (err.name === 'PreconditionFailedException' || err.name === 'InvalidArgumentException') {
+      const fresh = await refreshEtag();
+      const retry = await kvs.send(new DeleteKeyCommand({
+        KvsARN: process.env.KVS_ARN,
+        Key: code,
+        IfMatch: fresh,
+      }));
+      return retry.ETag || fresh;
+    }
+    throw err;
+  }
+}
+
+async function deletePartition(pk) {
+  let lastEvaluatedKey;
+  do {
+    const result = await ddb.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: marshall({ ':pk': pk }),
+      ProjectionExpression: '#pk, sk',
+      ExclusiveStartKey: lastEvaluatedKey,
+    }));
+
+    const items = result.Items || [];
+    for (let i = 0; i < items.length; i += 25) {
+      const batch = items.slice(i, i + 25).map((it) => {
+        const row = unmarshall(it);
+        return { DeleteRequest: { Key: marshall({ pk: row.pk, sk: row.sk }) } };
+      });
+      if (batch.length === 0) continue;
+      await ddb.send(new BatchWriteItemCommand({
+        RequestItems: { [process.env.TABLE_NAME]: batch },
+      }));
+    }
+    lastEvaluatedKey = result.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+}

--- a/links/README.md
+++ b/links/README.md
@@ -1,0 +1,68 @@
+# @readysetcloud/links
+
+Node client for the Ready, Set, Cloud link-shortening service. Mint short links,
+manage them, and read click analytics from any RSC app's backend without
+hand-rolling SigV4-signed HTTP.
+
+The service itself (edge redirect, management API, analytics, expiry) lives in
+[rsc-core](https://github.com/readysetcloud/rsc-core) — see
+[`functions/LINKS.md`](https://github.com/readysetcloud/rsc-core/blob/main/functions/LINKS.md).
+
+## Install
+
+```bash
+npm install @readysetcloud/links
+```
+
+## Auth & configuration
+
+The management API is **IAM-authorized**. Requests are signed with the ambient
+AWS credentials (service `execute-api`), so the calling Lambda's execution role
+must be granted `execute-api:Invoke` on the links API:
+
+```yaml
+- Effect: Allow
+  Action: execute-api:Invoke
+  Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${LinksApiId}/Prod/*/*
+```
+
+The API base URL is taken from `process.env.LINKS_API_URL` when set, otherwise
+resolved (and cached) from SSM at `/readysetcloud/links/api-base-url`. Resolving
+from SSM needs `ssm:GetParameter` on that parameter; setting `LINKS_API_URL`
+directly (e.g. via `{{resolve:ssm:/readysetcloud/links/api-base-url}}` at deploy)
+avoids the runtime lookup.
+
+## Usage
+
+```ts
+import {
+  createShortLink,
+  getShortLink,
+  updateShortLink,
+  deleteShortLink,
+  getLinkAnalytics,
+  getCampaignLinkAnalytics,
+} from '@readysetcloud/links';
+
+// Mint — returns { code, short_url, expires_at }
+const { short_url } = await createShortLink({
+  url: 'https://example.com/blog/post',
+  src: 'newsletter',       // optional source tag recorded on every click
+  campaignId: 'launch-2026', // optional — groups links for campaign analytics
+  expiresInDays: 90,        // optional — 1..1825, default 730
+});
+
+const link = await getShortLink('aB3xY9');
+await updateShortLink('aB3xY9', { url: 'https://example.com/new' });
+
+const stats = await getLinkAnalytics('aB3xY9');
+// { total_clicks, by_day, by_src, first_click_at, last_click_at }
+
+const campaign = await getCampaignLinkAnalytics('launch-2026');
+// { total_links, total_clicks, links: [{ ...link, analytics }] }
+
+await deleteShortLink('aB3xY9');
+```
+
+Non-2xx responses throw a `LinksApiError` carrying `status`, `message`, and the
+parsed `body`.

--- a/links/package-lock.json
+++ b/links/package-lock.json
@@ -1,0 +1,1781 @@
+{
+  "name": "@readysetcloud/links",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@readysetcloud/links",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-sdk/client-ssm": "^3.1086.0",
+        "@aws-sdk/credential-providers": "^3.1086.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/signature-v4": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^4.1.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1090.0.tgz",
+      "integrity": "sha512-8nYV/qnr+lr+xcsLBzx4iFWsl1zIT8Uf9uS2xevpfuFM0BT6IIIisAuxrotr7Rng3YgqDRx78JZKNp87iR+7uA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.58.tgz",
+      "integrity": "sha512-s5uoABv5eOzuH/S+XngHjHSrY8mK0UTBUFs8pm1ynBNuxXmYp176zarDyxN9lUS3Rry0wjzNvJUV09QROaO98g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1090.0.tgz",
+      "integrity": "sha512-HEfLv6RdiFu8+HO5CUQjjQ/KCWWAHcQCtSPenaF26lYQSjjzKjgvjwAMGBV9/VMrO8V0faIRyoFWhF548UjTOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.58",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.10.tgz",
+      "integrity": "sha512-0AnsOUvCHQBOXnBJbrX9QGidpvbb3F4aIUFlWPXCfRYxYCcoxj9Uq+b8j75wIZRIwhwiKDWJDZmoHjjQ82GYZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/links/package.json
+++ b/links/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@readysetcloud/links",
+  "version": "0.1.0",
+  "description": "Node client for the Ready, Set, Cloud link-shortening service: mint short links, manage them, and read click analytics over the IAM-authed core links API.",
+  "author": "allenheltondev",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/readysetcloud/rsc-core.git",
+    "directory": "links"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/client-ssm": "^3.1086.0",
+    "@aws-sdk/credential-providers": "^3.1086.0",
+    "@smithy/protocol-http": "^5.0.0",
+    "@smithy/signature-v4": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/links/src/index.test.ts
+++ b/links/src/index.test.ts
@@ -1,0 +1,135 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Configure the client for signing before import: a fixed API URL (skips SSM)
+// and static credentials so SigV4 signing is deterministic.
+process.env.LINKS_API_URL = 'https://abc123.execute-api.us-east-1.amazonaws.com/Prod';
+process.env.AWS_REGION = 'us-east-1';
+process.env.AWS_ACCESS_KEY_ID = 'AKIAEXAMPLE';
+process.env.AWS_SECRET_ACCESS_KEY = 'secretexamplekey';
+delete process.env.AWS_SESSION_TOKEN;
+
+const {
+  createShortLink,
+  getShortLink,
+  updateShortLink,
+  deleteShortLink,
+  getLinkAnalytics,
+  getCampaignLinkAnalytics,
+  LinksApiError,
+} = await import('./index.js');
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(body === undefined ? null : JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+beforeAll(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+const lastCall = () => {
+  const [url, init] = fetchMock.mock.calls.at(-1)!;
+  return { url: String(url), init: init as RequestInit & { headers: Record<string, string> } };
+};
+
+describe('createShortLink', () => {
+  it('POSTs a SigV4-signed request to /links with the JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(201, { code: 'aB3xY9', short_url: 'https://rdyset.click/aB3xY9', expires_at: '2027-01-01T00:00:00.000Z' })
+    );
+
+    const result = await createShortLink({ url: 'https://example.com', src: 'newsletter', campaignId: 'launch' });
+
+    expect(result.code).toBe('aB3xY9');
+    const { url, init } = lastCall();
+    expect(init.method).toBe('POST');
+    expect(url).toBe('https://abc123.execute-api.us-east-1.amazonaws.com/Prod/links');
+    expect(init.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+    expect(init.headers['x-amz-date']).toBeTruthy();
+    expect(JSON.parse(String(init.body))).toEqual({
+      url: 'https://example.com',
+      src: 'newsletter',
+      campaignId: 'launch',
+    });
+  });
+});
+
+describe('getShortLink', () => {
+  it('GETs /links/{code} and returns the metadata', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { code: 'aB3xY9', url: 'https://example.com' }));
+
+    const link = await getShortLink('aB3xY9');
+
+    expect(link.url).toBe('https://example.com');
+    const { url, init } = lastCall();
+    expect(init.method).toBe('GET');
+    expect(url).toBe('https://abc123.execute-api.us-east-1.amazonaws.com/Prod/links/aB3xY9');
+    expect(init.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 /);
+  });
+});
+
+describe('updateShortLink', () => {
+  it('PUTs the new destination', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { code: 'aB3xY9', url: 'https://new.example.com' }));
+
+    await updateShortLink('aB3xY9', { url: 'https://new.example.com' });
+
+    const { url, init } = lastCall();
+    expect(init.method).toBe('PUT');
+    expect(url).toBe('https://abc123.execute-api.us-east-1.amazonaws.com/Prod/links/aB3xY9');
+    expect(JSON.parse(String(init.body))).toEqual({ url: 'https://new.example.com' });
+  });
+});
+
+describe('deleteShortLink', () => {
+  it('DELETEs and tolerates an empty 204 body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(204, undefined));
+
+    await expect(deleteShortLink('aB3xY9')).resolves.toBeUndefined();
+
+    const { init } = lastCall();
+    expect(init.method).toBe('DELETE');
+  });
+});
+
+describe('analytics', () => {
+  it('reads per-code analytics', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { code: 'aB3xY9', total_clicks: 5, by_day: {}, by_src: {} }));
+
+    const analytics = await getLinkAnalytics('aB3xY9');
+
+    expect(analytics.total_clicks).toBe(5);
+    expect(lastCall().url).toBe('https://abc123.execute-api.us-east-1.amazonaws.com/Prod/links/aB3xY9/analytics');
+  });
+
+  it('reads per-campaign analytics with an encoded campaign id', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { campaign_id: 'a/b', total_links: 0, total_clicks: 0, links: [] }));
+
+    await getCampaignLinkAnalytics('a/b');
+
+    expect(lastCall().url).toBe(
+      'https://abc123.execute-api.us-east-1.amazonaws.com/Prod/campaigns/a%2Fb/links/analytics'
+    );
+  });
+});
+
+describe('error handling', () => {
+  it('throws LinksApiError with the API message on non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(400, { message: 'url is required' }));
+
+    await expect(createShortLink({ url: '' })).rejects.toMatchObject({
+      name: 'LinksApiError',
+      status: 400,
+      message: 'url is required',
+    });
+    expect(LinksApiError).toBeTypeOf('function');
+  });
+});

--- a/links/src/index.ts
+++ b/links/src/index.ts
@@ -1,0 +1,182 @@
+import { SignatureV4 } from '@smithy/signature-v4';
+import { HttpRequest } from '@smithy/protocol-http';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
+/**
+ * Client for the Ready, Set, Cloud link-shortening service.
+ *
+ * The service lives in `rsc-core`; this package lets any RSC app's backend mint
+ * and manage short links without hand-rolling SigV4-signed HTTP. Requests are
+ * signed with the ambient AWS credentials (service `execute-api`), so the
+ * calling Lambda's role must be granted `execute-api:Invoke` on the links API.
+ *
+ * The API base URL is taken from `process.env.LINKS_API_URL` when set, otherwise
+ * resolved (and cached) from SSM at `/readysetcloud/links/api-base-url`.
+ */
+
+const SSM_PARAM = '/readysetcloud/links/api-base-url';
+
+export interface ShortLink {
+  code: string;
+  short_url: string;
+  url: string;
+  src: string | null;
+  campaign_id: string | null;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+}
+
+export interface MintedShortLink {
+  code: string;
+  short_url: string;
+  expires_at: string;
+}
+
+export interface LinkAnalytics {
+  code: string;
+  total_clicks: number;
+  by_day: Record<string, number>;
+  by_src: Record<string, number>;
+  first_click_at: string | null;
+  last_click_at: string | null;
+}
+
+export interface CampaignLinkAnalytics {
+  campaign_id: string;
+  total_links: number;
+  total_clicks: number;
+  links: Array<ShortLink & { analytics: LinkAnalytics }>;
+}
+
+export interface CreateShortLinkInput {
+  /** Destination URL. Must be http(s) and <= 2048 chars. */
+  url: string;
+  /** Optional source/campaign tag recorded on every click (e.g. "newsletter"). */
+  src?: string;
+  /** Optional campaign id to group links for aggregate analytics (<= 128 chars). */
+  campaignId?: string;
+  /** Days until the code expires and is swept (1..1825, default 730). */
+  expiresInDays?: number;
+}
+
+export interface UpdateShortLinkInput {
+  url: string;
+  src?: string | null;
+}
+
+/** Thrown when the links API responds with a non-2xx status. */
+export class LinksApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(status: number, message: string, body: unknown) {
+    super(message);
+    this.name = 'LinksApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+let cachedBaseUrl: string | undefined;
+let signer: SignatureV4 | undefined;
+
+async function resolveBaseUrl(): Promise<string> {
+  if (process.env.LINKS_API_URL) return process.env.LINKS_API_URL;
+  if (cachedBaseUrl) return cachedBaseUrl;
+  // Loaded lazily so callers that set LINKS_API_URL never pull in the SSM client.
+  const { SSMClient, GetParameterCommand } = await import('@aws-sdk/client-ssm');
+  const client = new SSMClient({});
+  const result = await client.send(new GetParameterCommand({ Name: SSM_PARAM }));
+  const value = result.Parameter?.Value;
+  if (!value) {
+    throw new Error(
+      `Links API URL not found. Set LINKS_API_URL or the SSM parameter ${SSM_PARAM}.`
+    );
+  }
+  cachedBaseUrl = value;
+  return value;
+}
+
+function getSigner(region: string): SignatureV4 {
+  if (!signer) {
+    signer = new SignatureV4({
+      service: 'execute-api',
+      region,
+      credentials: fromNodeProviderChain(),
+      sha256: Sha256,
+    });
+  }
+  return signer;
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T | undefined> {
+  const base = (await resolveBaseUrl()).replace(/\/$/, '');
+  const url = new URL(base + path);
+  const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+
+  const headers: Record<string, string> = { host: url.hostname };
+  if (payload !== undefined) headers['content-type'] = 'application/json';
+
+  const signed = await getSigner(region).sign(
+    new HttpRequest({
+      method,
+      protocol: url.protocol,
+      hostname: url.hostname,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers,
+      body: payload,
+    })
+  );
+
+  const res = await fetch(url.toString(), {
+    method,
+    headers: signed.headers,
+    body: payload,
+  });
+
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : undefined;
+  if (!res.ok) {
+    const message =
+      (data && typeof data === 'object' && 'message' in data && String((data as { message: unknown }).message)) ||
+      `Links API request failed with status ${res.status}`;
+    throw new LinksApiError(res.status, message, data);
+  }
+  return data as T;
+}
+
+/** Mint a new short link. Returns the code, full short URL, and expiry. */
+export async function createShortLink(input: CreateShortLinkInput): Promise<MintedShortLink> {
+  return (await request<MintedShortLink>('POST', '/links', input))!;
+}
+
+/** Fetch a short link's metadata by code. */
+export async function getShortLink(code: string): Promise<ShortLink> {
+  return (await request<ShortLink>('GET', `/links/${encodeURIComponent(code)}`))!;
+}
+
+/** Update a short link's destination (and optional source tag) by code. */
+export async function updateShortLink(code: string, input: UpdateShortLinkInput): Promise<ShortLink> {
+  return (await request<ShortLink>('PUT', `/links/${encodeURIComponent(code)}`, input))!;
+}
+
+/** Delete a short link (metadata, clicks, and the edge redirect entry). */
+export async function deleteShortLink(code: string): Promise<void> {
+  await request<void>('DELETE', `/links/${encodeURIComponent(code)}`);
+}
+
+/** Read per-code click analytics (totals, by-day, by-source). */
+export async function getLinkAnalytics(code: string): Promise<LinkAnalytics> {
+  return (await request<LinkAnalytics>('GET', `/links/${encodeURIComponent(code)}/analytics`))!;
+}
+
+/** Read aggregate analytics across every link in a campaign. */
+export async function getCampaignLinkAnalytics(campaignId: string): Promise<CampaignLinkAnalytics> {
+  return (await request<CampaignLinkAnalytics>(
+    'GET',
+    `/campaigns/${encodeURIComponent(campaignId)}/links/analytics`
+  ))!;
+}

--- a/links/tsconfig.check.json
+++ b/links/tsconfig.check.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/links/tsconfig.json
+++ b/links/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/links/vitest.config.ts
+++ b/links/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,32 +9,38 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-lambda-powertools/event-handler": "^2.34.0",
         "@aws-lambda-powertools/parameters": "^2.34.0",
         "@gomomento/sdk": "^1.118.0",
         "@readysetcloud/agent": "file:agent",
+        "@readysetcloud/links": "file:links",
         "@sendgrid/mail": "^8.1.6",
         "octokit": "^5.0.5",
-        "openai": "^6.46.0"
+        "openai": "^6.46.0",
+        "ulid": "^2.3.0"
       },
       "devDependencies": {
         "@aws-sdk/client-amplify": "^3.1086.0",
+        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1086.0",
         "@aws-sdk/client-dynamodb": "^3.1086.0",
         "@aws-sdk/client-eventbridge": "^3.1086.0",
         "@aws-sdk/client-lambda": "^3.1086.0",
         "@aws-sdk/client-s3": "^3.1086.0",
         "@aws-sdk/client-ssm": "^3.1086.0",
         "@aws-sdk/credential-providers": "^3.1086.0",
+        "@aws-sdk/signature-v4a": "^3.1086.0",
         "@aws-sdk/util-dynamodb": "^3.996.6",
         "@eslint/js": "^10.0.1",
         "eslint": "^10.7.0",
         "eslint-config-google": "^0.14.0",
         "globals": "^17.7.0",
-        "sharp": "^0.35.3"
+        "sharp": "^0.35.3",
+        "vitest": "^4.1.2"
       }
     },
     "agent": {
       "name": "@readysetcloud/agent",
-      "version": "0.2.3",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1085.0",
@@ -59,6 +65,58 @@
         "undici-types": "~6.21.0"
       }
     },
+    "links": {
+      "name": "@readysetcloud/links",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-sdk/client-ssm": "^3.1086.0",
+        "@aws-sdk/credential-providers": "^3.1086.0",
+        "@smithy/protocol-http": "^5.0.0",
+        "@smithy/signature-v4": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^4.1.2"
+      }
+    },
+    "links/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@aws-lambda-powertools/commons": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.34.0.tgz",
@@ -66,6 +124,28 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws/lambda-invoke-store": "0.3.0"
+      }
+    },
+    "node_modules/@aws-lambda-powertools/event-handler": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/event-handler/-/event-handler-2.34.0.tgz",
+      "integrity": "sha512-vsTxFAWn1AOYl3aHR0RhzU+Bd1kRkbKDmywJnsnae7Mu61bjyUylAakGOspDf0PueiDYYsq2vlGgz7vIa1qfTA==",
+      "license": "MIT-0",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "2.34.0"
+      },
+      "peerDependencies": {
+        "@aws-lambda-powertools/metrics": ">=2.34.0",
+        "@aws-lambda-powertools/tracer": ">=2.34.0",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-lambda-powertools/metrics": {
+          "optional": true
+        },
+        "@aws-lambda-powertools/tracer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-lambda-powertools/parameters": {
@@ -182,6 +262,27 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudfront-keyvaluestore": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront-keyvaluestore/-/client-cloudfront-keyvaluestore-3.1090.0.tgz",
+      "integrity": "sha512-CZNRufb2Em1wFiiwqDXlcXdC+Ffgii7kGiv+yZjCrrNZ0ilJtTNNzU3Q3ZMytW19AtgaISQEioSIWo9wcbQ7hg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1086.0.tgz",
@@ -270,7 +371,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1086.0.tgz",
       "integrity": "sha512-FPyxcVdiiwvb+SS29oMrzPh2byOyKT8XRBynhII8z6iFcZ/ySdRnyDpZ+0yolzOyCFhH/X+lPidNxlc01ZOglQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -287,17 +387,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -309,7 +409,6 @@
       "version": "3.972.56",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.56.tgz",
       "integrity": "sha512-nedaZz6Wz2FGUBMsWhlvBPGIkTMfRuMJ99YDHJI4CaC31JS8WPyTavEAio74cfd5nGhi0A8XASB4fZA5VqTdOQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/nested-clients": "^3.997.31",
@@ -323,15 +422,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -339,17 +438,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -357,23 +456,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-login": "^3.972.63",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -381,16 +480,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -398,21 +497,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
-      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-ini": "^3.973.1",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -420,15 +519,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -436,17 +535,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/token-providers": "3.1083.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -454,16 +553,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -474,7 +573,6 @@
       "version": "3.1086.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1086.0.tgz",
       "integrity": "sha512-4Vewvblp1JXL9Qtf9+srAsksBp1PmAJGk6T0hM0YcZdYDrbSE9Lpy9iTraumJqQACSTTkjqXSlaISrEGn2c5hw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -628,18 +726,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -647,14 +745,28 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4a": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4a/-/signature-v4a-3.1088.0.tgz",
+      "integrity": "sha512-NQNZ0Gu6cewCJxyWcUzO/wSAu0mSXk7wjN1PpT8VlXS//rOKNudaQhCt9xdbWs33j3Aeevp4/LD9JWYAKb+R2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/signature-v4a": "^3.5.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -662,16 +774,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -679,12 +791,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -707,12 +819,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2101,6 +2213,10 @@
       "resolved": "agent",
       "link": true
     },
+    "node_modules/@readysetcloud/links": {
+      "resolved": "links",
+      "link": true
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2415,9 +2531,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2428,12 +2544,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2442,12 +2558,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
-      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2455,14 +2571,39 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.10.tgz",
+      "integrity": "sha512-0AnsOUvCHQBOXnBJbrX9QGidpvbb3F4aIUFlWPXCfRYxYCcoxj9Uq+b8j75wIZRIwhwiKDWJDZmoHjjQ82GYZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2470,12 +2611,28 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
-      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4a": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4a/-/signature-v4a-3.5.2.tgz",
+      "integrity": "sha512-pV2Elv2SddGRg/vhE6eV2C0an5dptUqpJ7fTfiXegaW9yyz8mhiJQ0X42tpV4doova0DiwPT8WXAx5teYJBdpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/signature-v4": "^5.6.6",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2495,11 +2652,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@strands-agents/sdk": {
@@ -5682,6 +5864,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Core resources, components, and configuration for Ready, Set, Cloud",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "lint": "eslint ."
   },
   "repository": {
@@ -24,19 +24,25 @@
     "@aws-sdk/client-s3": "^3.1086.0",
     "@aws-sdk/client-ssm": "^3.1086.0",
     "@aws-sdk/credential-providers": "^3.1086.0",
+    "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1086.0",
+    "@aws-sdk/signature-v4a": "^3.1086.0",
     "@aws-sdk/util-dynamodb": "^3.996.6",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.7.0",
     "eslint-config-google": "^0.14.0",
     "globals": "^17.7.0",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "vitest": "^4.1.2"
   },
   "dependencies": {
+    "@aws-lambda-powertools/event-handler": "^2.34.0",
     "@aws-lambda-powertools/parameters": "^2.34.0",
     "@gomomento/sdk": "^1.118.0",
     "@readysetcloud/agent": "file:agent",
+    "@readysetcloud/links": "file:links",
     "@sendgrid/mail": "^8.1.6",
     "octokit": "^5.0.5",
-    "openai": "^6.46.0"
+    "openai": "^6.46.0",
+    "ulid": "^2.3.0"
   }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -74,6 +74,20 @@ Parameters:
       grant allows any system id for that sub). Empty (default) rejects all
       system-scoped API requests — opt in explicitly, like McpAllowedHosts.
       First-party backends that emit "Run Agent Task" events are unaffected.
+  LinkRedirectDomain:
+    Type: String
+    Default: ''
+    Description: >
+      Optional custom domain for short-link redirects (e.g. rdyset.click). When
+      set (and HostedZoneId is provided) the redirect distribution is fronted by
+      this domain and short URLs are https://<domain>/<code>; otherwise they use
+      the generated CloudFront domain.
+  LinkRedirectFallbackUrl:
+    Type: String
+    Default: 'https://readysetcloud.io'
+    Description: >
+      Where the edge redirect sends visitors when a short code is missing,
+      expired, or malformed.
 
 Metadata:
   esbuild-properties: &esbuild-properties
@@ -94,6 +108,9 @@ Metadata:
 Conditions:
   DeployCustomDomainSupport:
     !Not [!Equals [!Ref RootDomainName, '']]
+  HasLinkRedirectDomain: !And
+    - !Not [!Equals [!Ref LinkRedirectDomain, '']]
+    - !Not [!Equals [!Ref HostedZoneId, '']]
 
 Globals:
   Function:
@@ -1348,3 +1365,374 @@ Resources:
         RootDomainName: !Ref RootDomainName
         HostedZoneId: !Ref HostedZoneId
         S3BucketName: !Ref BucketName
+
+  # ----------------------------------------------------------------------------
+  # Link shortening — short links, redirects & campaigns
+  #
+  # A reusable, ecosystem-wide URL shortener. Any RSC app mints a 6-char code for
+  # a destination URL (service-to-service via @readysetcloud/links, IAM-signed),
+  # visitors hit https://<redirect-domain>/<code> and are 302'd at the CloudFront
+  # edge (no Lambda in the hot path), and every redirect is logged and rolled up
+  # into per-code and per-campaign click analytics. Expired codes are swept daily.
+  #
+  # Pieces: LinksTable (data) · LinkKeyValueStore + LinkRedirectFunction +
+  # LinkRedirectDistribution (public edge redirect) · LinksApi + ManageLinks
+  # (IAM-authed management, one mono-Lambda routed by Powertools) ·
+  # ProcessLinkClick (edge logs → analytics) · SweepExpiredLinks (daily TTL).
+  # ----------------------------------------------------------------------------
+  LinksTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+        - AttributeName: GSI1PK
+          AttributeType: S
+        - AttributeName: GSI1SK
+          AttributeType: S
+        - AttributeName: GSI2PK
+          AttributeType: S
+        - AttributeName: GSI2SK
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        # GSI1 — expiry sweep: LINK_EXPIRY / {expiresAt ISO}
+        - IndexName: GSI1
+          KeySchema:
+            - AttributeName: GSI1PK
+              KeyType: HASH
+            - AttributeName: GSI1SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: KEYS_ONLY
+        # GSI2 — campaign grouping: LINK_CAMPAIGN#{campaignId} / LINK#{createdAt}#{code}
+        - IndexName: GSI2
+          KeySchema:
+            - AttributeName: GSI2PK
+              KeyType: HASH
+            - AttributeName: GSI2SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+  LinkKeyValueStore:
+    Type: AWS::CloudFront::KeyValueStore
+    Properties:
+      Name: rsc-short-links
+      Comment: Maps short codes to short-link destinations for the edge redirect
+
+  LinkRedirectFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      AutoPublish: true
+      FunctionCode: !Sub |
+        import cf from 'cloudfront';
+
+        const kvsId = '${LinkKeyValueStore.Id}';
+        const kvsHandle = cf.kvs(kvsId);
+
+        async function handler(event) {
+          const req = event.request || {};
+          const qs = req.querystring || {};
+          const headers = req.headers || {};
+
+          const FALLBACK_URL = '${LinkRedirectFallbackUrl}';
+
+          function get(n){ return qs[n] && qs[n].value; }
+          const srcOverride = get('src');
+          const s = get('s') || null;
+          const ip = (event.viewer && event.viewer.ip) || null;
+
+          function redirect(to){
+            return {
+              statusCode: 302,
+              statusDescription: 'Found',
+              headers: {
+                location: { value: to },
+                'cache-control': { value: 'no-store' },
+                'referrer-policy': { value: 'no-referrer-when-downgrade' },
+                'x-content-type-options': { value: 'nosniff' }
+              }
+            };
+          }
+
+          function fallback(reason){
+            const q = '?reason=' + encodeURIComponent(reason);
+            const to = FALLBACK_URL + (FALLBACK_URL.indexOf('?') === -1 ? q : '&' + q.slice(1));
+            return redirect(to);
+          }
+
+          const pieces = (req.uri || '').split('/');
+          const code = pieces[pieces.length - 1];
+          if (!code || !/^[A-Za-z0-9]{4,12}$/.test(code)) return fallback('bad_code');
+
+          let entry;
+          try {
+            const raw = await kvsHandle.get(code);
+            entry = JSON.parse(raw);
+          } catch (err) {
+            return fallback('code_not_found');
+          }
+
+          const dest = entry && entry.u;
+          const src = srcOverride || (entry && entry.src) || 'web';
+
+          if (!dest || !/^https?:\/\//i.test(dest)) return fallback('bad_dest');
+
+          const hostHdr = (headers.host && headers.host[0] && headers.host[0].value) || '';
+          let destHost = '';
+          try { destHost = dest.split('/')[2].toLowerCase(); } catch(e) { return fallback('bad_url'); }
+          if (hostHdr && destHost === hostHdr.toLowerCase()) return fallback('loop_to_tracker');
+
+          if (dest.length > 2048) return fallback('url_too_long');
+
+          try { console.log(JSON.stringify({ code, u: dest, src, ip, s })); } catch(_) {}
+          return redirect(dest);
+        }
+      FunctionConfig:
+        KeyValueStoreAssociations:
+          - KeyValueStoreARN: !GetAtt LinkKeyValueStore.Arn
+        Runtime: cloudfront-js-2.0
+        Comment: Short-code edge redirect
+      Name: rsc-link-redirect
+
+  LinkRedirectLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 3
+      LogGroupName: /aws/cloudfront/function/rsc-link-redirect
+
+  LinkRedirectCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: HasLinkRedirectDomain
+    Properties:
+      DomainName: !Ref LinkRedirectDomain
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Ref LinkRedirectDomain
+          HostedZoneId: !Ref HostedZoneId
+
+  LinkRedirectDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          Compress: false
+          # Managed CachingDisabled — redirects must never be cached.
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt LinkRedirectFunction.FunctionMetadata.FunctionARN
+          TargetOriginId: dummy.origin
+          ViewerProtocolPolicy: redirect-to-https
+        Enabled: true
+        PriceClass: PriceClass_100
+        Origins:
+          - DomainName: dummy.origin
+            Id: dummy.origin
+            CustomOriginConfig:
+              OriginProtocolPolicy: match-viewer
+        ViewerCertificate: !If
+          - HasLinkRedirectDomain
+          - AcmCertificateArn: !Ref LinkRedirectCertificate
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2_2021
+          - CloudFrontDefaultCertificate: true
+        Aliases: !If
+          - HasLinkRedirectDomain
+          - [!Ref LinkRedirectDomain]
+          - !Ref 'AWS::NoValue'
+
+  LinkRedirectRecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: HasLinkRedirectDomain
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref LinkRedirectDomain
+      Type: A
+      AliasTarget:
+        HostedZoneId: Z2FDTNDATAQYW2
+        DNSName: !GetAtt LinkRedirectDistribution.DomainName
+
+  LinkRedirectRecordSetIPV6:
+    Type: AWS::Route53::RecordSet
+    Condition: HasLinkRedirectDomain
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref LinkRedirectDomain
+      Type: AAAA
+      AliasTarget:
+        HostedZoneId: Z2FDTNDATAQYW2
+        DNSName: !GetAtt LinkRedirectDistribution.DomainName
+
+  # Management API — IAM-authed, service-to-service. The @readysetcloud/links
+  # client signs requests with SigV4; consuming apps grant execute-api:Invoke.
+  LinksApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer: AWS_IAM
+
+  ManageLinksFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - manage-links.mjs
+        # Self-bundle the SDK: the CloudFront KVS + SigV4a clients aren't
+        # guaranteed to be in the managed runtime like the common ones are.
+        External: []
+    Properties:
+      Handler: manage-links.handler
+      Timeout: 10
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref LinksTable
+          KVS_ARN: !GetAtt LinkKeyValueStore.Arn
+          SHORT_LINK_BASE: !If
+            - HasLinkRedirectDomain
+            - !Sub 'https://${LinkRedirectDomain}'
+            - !Sub 'https://${LinkRedirectDistribution.DomainName}'
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+                - dynamodb:Query
+                - dynamodb:BatchGetItem
+                - dynamodb:BatchWriteItem
+              Resource:
+                - !GetAtt LinksTable.Arn
+                - !Sub '${LinksTable.Arn}/index/GSI2'
+            - Effect: Allow
+              Action:
+                - cloudfront-keyvaluestore:DescribeKeyValueStore
+                - cloudfront-keyvaluestore:PutKey
+                - cloudfront-keyvaluestore:DeleteKey
+              Resource: !GetAtt LinkKeyValueStore.Arn
+      Events:
+        Manage:
+          Type: Api
+          Properties:
+            RestApiId: !Ref LinksApi
+            Path: /{proxy+}
+            Method: ANY
+
+  ProcessLinkClickFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - process-link-click.mjs
+        External: []
+    Properties:
+      Handler: process-link-click.handler
+      Timeout: 30
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref LinksTable
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt LinksTable.Arn
+
+  ProcessLinkClickLogPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref ProcessLinkClickFunction
+      Principal: !Sub 'logs.${AWS::Region}.amazonaws.com'
+      SourceArn: !GetAtt LinkRedirectLogGroup.Arn
+
+  LinkClickSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    DependsOn: ProcessLinkClickLogPermission
+    Properties:
+      LogGroupName: !Ref LinkRedirectLogGroup
+      FilterPattern: '"code"'
+      DestinationArn: !GetAtt ProcessLinkClickFunction.Arn
+
+  SweepExpiredLinksFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - sweep-expired-links.mjs
+        External: []
+    Properties:
+      Handler: sweep-expired-links.handler
+      Timeout: 300
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref LinksTable
+          KVS_ARN: !GetAtt LinkKeyValueStore.Arn
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:Query
+                - dynamodb:DeleteItem
+                - dynamodb:BatchWriteItem
+              Resource:
+                - !GetAtt LinksTable.Arn
+                - !Sub '${LinksTable.Arn}/index/GSI1'
+            - Effect: Allow
+              Action:
+                - cloudfront-keyvaluestore:DescribeKeyValueStore
+                - cloudfront-keyvaluestore:DeleteKey
+              Resource: !GetAtt LinkKeyValueStore.Arn
+      Events:
+        DailySweep:
+          Type: Schedule
+          Properties:
+            Schedule: 'cron(0 7 * * ? *)'
+
+  LinkShortBaseParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/links/short-link-base
+      Type: String
+      Value: !If
+        - HasLinkRedirectDomain
+        - !Sub 'https://${LinkRedirectDomain}'
+        - !Sub 'https://${LinkRedirectDistribution.DomainName}'
+      Description: Base URL for short links (append /{code})
+
+  LinksApiUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /readysetcloud/links/api-base-url
+      Type: String
+      Value: !Sub 'https://${LinksApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod'
+      Description: >
+        Base URL of the IAM-authed link management API. @readysetcloud/links
+        signs requests against this host.

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Root config runs the Lambda function tests under functions/. The workspace
+// packages (agent/, links/) have their own vitest configs and are excluded here.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['functions/**/*.test.mjs'],
+  },
+});


### PR DESCRIPTION
## Summary

Introduces a complete link-shortening service for Ready, Set, Cloud. Any app can mint 6-character short codes for destination URLs, serve fast edge redirects via CloudFront (no Lambda in hot path), group codes into campaigns, and track per-code and per-campaign click analytics. Expired codes are swept daily.

## Key Changes

**Backend Infrastructure (`functions/manage-links.mjs`)**
- IAM-authorized REST API (POST/GET/PUT/DELETE `/links`, analytics endpoints)
- Mint short codes with collision detection and retry logic
- Store metadata in DynamoDB with GSI support for expiry and campaign grouping
- Write code→URL mappings to CloudFront Key Value Store for edge access
- Format and return link metadata and analytics

**Edge Redirect (`functions/manage-links.mjs` CloudFront Function)**
- CloudFront Function (not Lambda) reads KVS for code→URL mapping
- 302 redirects with no caching, logs compact JSON events
- Fallback URL for missing/expired/malformed codes
- Loop detection to prevent redirecting back to tracker domain

**Click Analytics Pipeline**
- `process-link-click.mjs`: Consumes CloudWatch Logs subscription from edge function, records individual click events and rolls up aggregates (total clicks, by day, by source, first/last click timestamps)
- `sweep-expired-links.mjs`: Daily scheduled task queries GSI1 for expired codes, deletes from both DynamoDB and KVS

**Client Library (`links/src/index.ts`)**
- TypeScript client for service-to-service calls: `createShortLink`, `getShortLink`, `updateShortLink`, `deleteShortLink`, `getLinkAnalytics`, `getCampaignLinkAnalytics`
- SigV4-signed requests using ambient AWS credentials (service `execute-api`)
- API URL from `LINKS_API_URL` env var or SSM parameter `/readysetcloud/links/api-base-url`
- Published as `@readysetcloud/links` npm package

**CloudFormation Template**
- `LinksTable`: DynamoDB table with GSI1 (expiry sweep) and GSI2 (campaign grouping), TTL enabled
- `LinkKeyValueStore`: CloudFront Key Value Store for edge redirect lookups
- `LinkRedirectDistribution`: CloudFront distribution with custom domain support (optional `LinkRedirectDomain` parameter)
- `LinkRedirectFunction`: CloudFront Function for viewer-request redirect logic
- Optional Route53 records for custom redirect domain

**Testing & CI/CD**
- Unit tests for all Lambda functions and client library (Vitest)
- GitHub Actions: auto-bump `@readysetcloud/links` patch version on PR changes
- Publish workflow for npm package
- Path-based change detection in CI workflows

## Notable Implementation Details

- **No Lambda in hot path**: Edge redirect runs entirely at CloudFront edge via Function + KVS
- **Collision handling**: Allocates unique 6-char codes with up to 5 retries on collision
- **Campaign grouping**: GSI2 enables efficient queries of all links in a campaign with aggregate analytics
- **Click TTL**: Individual click events auto-expire after 90 days; aggregates persist
- **Fallback URL**: Configurable fallback (default `https://readysetcloud.io`) for invalid/expired codes
- **ETag management**: Handles CloudFront KVS ETag updates during concurrent deletes
- **Batch operations**: Uses batch DynamoDB operations for efficiency in analytics queries

https://claude.ai/code/session_01F3dZHLCeCPyBhrSQ3Tevky