### PR TITLE
Promote newsletter PR #364 analytics components into the design system and publish a GitHub Pages guide

### DIFF
--- a/.github/workflows/design-system-pages.yaml
+++ b/.github/workflows/design-system-pages.yaml
@@ -1,0 +1,58 @@
+name: Publish Design System Guide
+
+# The guide consumes the ui package's own stylesheets and browser bundles,
+# so it redeploys whenever either the guide or the package changes — docs
+# and package cannot drift.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ui/**'
+      - 'design-system/**'
+      - 'scripts/build-design-site.mjs'
+      - '.github/workflows/design-system-pages.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: design-system-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build guide from ui package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Build ui package
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+      - name: Assemble site
+        run: node scripts/build-design-site.mjs
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist-design-site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ out
 .nuxt
 dist
 
+# Assembled design-system guide (GitHub Pages artifact)
+dist-design-site
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ The configured deployment parameters above will be accessible by using the follo
 * Cognito User Pool Client ID - `{{resolve:ssm:/readysetcloud/auth/user-pool-client-id}}`
 * Core API URL - `{{resolve:ssm:/readysetcloud/api-url}}` (prod: `https://api.readysetcloud.io/core`)
 
+## Design system — `ui/`
+
+The shared Ready, Set, Cloud design system (`@readysetcloud/ui`) lives in
+[`ui/`](ui/): tokens, React components, framework-agnostic CSS classes, and
+hosted browser bundles. The full guide — palette, typography, live component
+demos, and theming rules — is published to GitHub Pages from
+[`design-system/`](design-system/) on every push to `main` that touches it or
+`ui/`, so the guide always reflects the shipped package. API details for
+consumers are in [`ui/AGENTS.md`](ui/AGENTS.md).
+
 ## Badge Chest — cross-app gamification
 
 The badge chest is a single, ecosystem-wide trophy case. Because every app

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,32 @@
+# Design system guide
+
+The GitHub Pages site for the Ready, Set, Cloud design system. Published by
+`.github/workflows/design-system-pages.yaml` on every push to `main` that
+touches this directory or `ui/`.
+
+## Staying in sync with the package
+
+The guide has no design assets of its own. Pages link the ui package's actual
+stylesheets (`ui/styles/index.css`), browser bundles (`ui/dist/browser/ui.global.js`),
+and logo — and the color swatches/specimens are read from the live CSS custom
+properties at render time (`site.js`). Change a token or a component class in
+`ui/` and the published guide re-renders with it; there is nothing to copy or
+regenerate by hand.
+
+`site.css` / `site.js` style and wire the guide chrome only — never put brand
+values in them.
+
+## Local preview
+
+```bash
+cd ui && npm install && npm run build && cd ..
+node scripts/build-design-site.mjs
+npx serve dist-design-site   # or: python3 -m http.server -d dist-design-site
+```
+
+## Adding a component to the guide
+
+When a component lands in `ui/`, add a demo block to `components.html`:
+preview markup using the shipped CSS classes, plus `<pre data-lang="react">`
+and `<pre data-lang="html">` snippets (the code tabs and copy buttons are
+generated automatically).

--- a/design-system/components.html
+++ b/design-system/components.html
@@ -1,0 +1,632 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Components · Ready, Set, Cloud Design System</title>
+  <meta name="description" content="Live, theme-aware demos of every @readysetcloud/ui component with side-by-side React and plain-HTML usage.">
+  <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
+  <link rel="stylesheet" href="ui/styles/fonts.css">
+  <link rel="stylesheet" href="ui/styles/index.css">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <nav class="app-nav">
+    <div class="app-nav-inner">
+      <a class="app-nav-brand" href="index.html">
+        <span class="app-nav-brand-mark"></span>
+        <span class="app-nav-brand-name">Ready, Set, Cloud</span>
+      </a>
+      <button class="app-nav-menu-btn" type="button" aria-label="Toggle navigation">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3zm0 5h18v2H3zm0 5h18v2H3z"/></svg>
+      </button>
+      <div class="app-nav-collapse">
+        <div class="app-nav-links">
+          <a class="app-nav-link" href="index.html">Overview</a>
+          <a class="app-nav-link" href="foundations.html">Foundations</a>
+          <a class="app-nav-link app-nav-link-active" href="components.html">Components</a>
+          <a class="app-nav-link" href="patterns.html">Patterns</a>
+        </div>
+        <div class="app-nav-actions">
+          <a class="app-nav-icon-btn" href="https://github.com/readysetcloud/rsc-core" aria-label="rsc-core on GitHub">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          </a>
+          <button class="app-nav-icon-btn" type="button" data-theme-toggle aria-label="Toggle light and dark theme">
+            <svg class="theme-icon-light" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1M12 1v3M12 20v3M1 12h3M20 12h3" stroke="currentColor" stroke-width="2"/></svg>
+            <svg class="theme-icon-dark" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="ds-shell">
+    <header class="page-hero">
+      <div class="page-hero-content">
+        <span class="ds-kicker">Components</span>
+        <h1 class="page-hero-title">Built once, rendered everywhere</h1>
+        <p class="page-hero-subtitle">
+          Every component ships as a typed React export <em>and</em> the plain CSS class it
+          renders — so a Hugo partial and a React page produce pixel-identical UI.
+          Demos below are live and theme-aware; flip the theme toggle to check dark mode.
+        </p>
+        <div class="page-hero-chips">
+          <span class="page-hero-chip page-hero-chip-primary">React + CSS parity</span>
+          <span class="page-hero-chip">Stable class names</span>
+        </div>
+      </div>
+    </header>
+
+    <ul class="ds-anchor-list">
+      <li><a href="#buttons">Buttons</a></li>
+      <li><a href="#badges">Badges</a></li>
+      <li><a href="#analytics">Analytics kit</a></li>
+      <li><a href="#hero">Page hero</a></li>
+      <li><a href="#cards">Cards</a></li>
+      <li><a href="#forms">Forms</a></li>
+      <li><a href="#feedback">Feedback</a></li>
+      <li><a href="#loading">Loading</a></li>
+      <li><a href="#navigation">Navigation</a></li>
+    </ul>
+
+    <section class="ds-section" id="buttons">
+      <span class="ds-kicker">Actions</span>
+      <h2>Buttons</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Variants &amp; sizes</h3>
+          <p>One primary action per view. <code>ghost</code> for tertiary actions, semantic variants for their outcomes.</p>
+        </div>
+        <div class="demo-preview">
+          <button class="btn btn-primary" type="button">Primary</button>
+          <button class="btn btn-secondary" type="button">Secondary</button>
+          <button class="btn btn-success" type="button">Success</button>
+          <button class="btn btn-warning" type="button">Warning</button>
+          <button class="btn btn-error" type="button">Error</button>
+          <button class="btn btn-ghost" type="button">Ghost</button>
+          <button class="btn btn-primary btn-sm" type="button">Small</button>
+          <button class="btn btn-primary btn-lg" type="button">Large</button>
+          <button class="btn btn-primary" type="button" disabled>Disabled</button>
+          <button class="btn btn-primary" type="button" disabled><span class="spinner"></span> Saving…</button>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Button } from '@readysetcloud/ui';
+
+&lt;Button variant="primary"&gt;Primary&lt;/Button&gt;
+&lt;Button variant="ghost" size="sm"&gt;Ghost&lt;/Button&gt;
+&lt;Button loading loadingLabel="Saving…"&gt;Save&lt;/Button&gt;</code></pre>
+<pre data-lang="html"><code>&lt;button class="btn btn-primary"&gt;Primary&lt;/button&gt;
+&lt;button class="btn btn-ghost btn-sm"&gt;Ghost&lt;/button&gt;
+&lt;button class="btn btn-primary" disabled&gt;
+  &lt;span class="spinner"&gt;&lt;/span&gt; Saving…
+&lt;/button&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="badges">
+      <span class="ds-kicker">Status</span>
+      <h2>Badges &amp; status</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Badge</h3>
+          <p>The uppercase mono tag — for categorical labels like tiers, environments, and content types.</p>
+        </div>
+        <div class="demo-preview">
+          <span class="badge badge-primary">Primary</span>
+          <span class="badge badge-success">Success</span>
+          <span class="badge badge-warning">Warning</span>
+          <span class="badge badge-error">Error</span>
+          <span class="badge badge-neutral">Neutral</span>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Badge } from '@readysetcloud/ui';
+
+&lt;Badge variant="success"&gt;Success&lt;/Badge&gt;</code></pre>
+<pre data-lang="html"><code>&lt;span class="badge badge-success"&gt;Success&lt;/span&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>StatusBadge</h3>
+          <p>The sentence-case health pill — for state readouts and threshold flags. One tone class is correct in both themes; the ramps invert for you.</p>
+        </div>
+        <div class="demo-preview">
+          <span class="status-badge status-badge-success" role="status"><span aria-hidden="true">✓</span> Stable</span>
+          <span class="status-badge status-badge-warning" role="status"><span aria-hidden="true">⚠</span> High</span>
+          <span class="status-badge status-badge-error" role="status"><span aria-hidden="true">✕</span> Critical</span>
+          <span class="status-badge status-badge-primary" role="status">Scheduled</span>
+          <span class="status-badge status-badge-neutral" role="status">Draft</span>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { StatusBadge } from '@readysetcloud/ui';
+
+&lt;StatusBadge tone="success" icon="✓"&gt;Stable&lt;/StatusBadge&gt;
+&lt;StatusBadge tone="warning" icon="⚠"&gt;High&lt;/StatusBadge&gt;</code></pre>
+<pre data-lang="html"><code>&lt;span class="status-badge status-badge-success" role="status"&gt;
+  &lt;span aria-hidden="true"&gt;✓&lt;/span&gt; Stable
+&lt;/span&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="analytics">
+      <span class="ds-kicker">Data display</span>
+      <h2>Analytics kit</h2>
+      <p class="ds-lede">
+        The shared language of the dashboards: metric tiles with delta pills, threshold badges,
+        and trend sparklines, plus the segmented control that switches their baseline.
+      </p>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>TrendPill</h3>
+          <p>Color encodes <em>improvement</em>, not direction — pass <code>invert</code> for metrics where down is good (bounce, unsubscribes). Zero deltas render neutral with no arrow.</p>
+        </div>
+        <div class="demo-preview">
+          <span class="trend-pill trend-pill-positive"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 10.5 8 5.5 13 10.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>+6.3%</span>
+          <span class="trend-pill trend-pill-negative"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 5.5 8 10.5 13 5.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>-2.1%</span>
+          <span class="trend-pill trend-pill-positive"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 5.5 8 10.5 13 5.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>-0.4% <span style="opacity:.7">(bounce ↓ = good)</span></span>
+          <span class="trend-pill trend-pill-neutral">No change</span>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { TrendPill } from '@readysetcloud/ui';
+
+&lt;TrendPill delta={6.3} /&gt;            // improvement → success colors
+&lt;TrendPill delta={-2.1} /&gt;           // decline → error colors
+&lt;TrendPill delta={-0.4} invert /&gt;    // bounce rate fell → improvement
+&lt;TrendPill delta={0} /&gt;              // neutral, no arrow</code></pre>
+<pre data-lang="html"><code>&lt;span class="trend-pill trend-pill-positive"&gt;
+  &lt;svg viewBox="0 0 16 16" aria-hidden="true"&gt;
+    &lt;path d="M3 10.5 8 5.5 13 10.5" fill="none"
+          stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round"/&gt;
+  &lt;/svg&gt;
+  +6.3%
+&lt;/span&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>SegmentedControl</h3>
+          <p>Compact multi-option toggle for comparison baselines, view switches, and filter tabs. State is exposed via <code>aria-pressed</code>. Try it — this one is live.</p>
+        </div>
+        <div class="demo-preview">
+          <span style="font-size: 0.75rem; color: rgb(var(--muted-foreground));">Compare to</span>
+          <div class="segmented-control" role="group" aria-label="Comparison baseline">
+            <button class="segmented-control-option" type="button" aria-pressed="true">Average</button>
+            <button class="segmented-control-option" type="button" aria-pressed="false">Last issue</button>
+            <button class="segmented-control-option" type="button" aria-pressed="false">Best issue</button>
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { SegmentedControl } from '@readysetcloud/ui';
+
+&lt;SegmentedControl
+  aria-label="Comparison baseline"
+  options={[
+    { value: 'average', label: 'Average' },
+    { value: 'last', label: 'Last issue' },
+    { value: 'best', label: 'Best issue' }
+  ]}
+  value={mode}
+  onChange={setMode}
+/&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="segmented-control" role="group" aria-label="Comparison baseline"&gt;
+  &lt;button class="segmented-control-option" aria-pressed="true"&gt;Average&lt;/button&gt;
+  &lt;button class="segmented-control-option" aria-pressed="false"&gt;Last issue&lt;/button&gt;
+  &lt;button class="segmented-control-option" aria-pressed="false"&gt;Best issue&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>StatTile + TrendSparkline</h3>
+          <p>The dashboard metric tile: uppercase label, display-font value, delta pill, threshold badge, caption, and a decorative sparkline with the latest point emphasized. Sparklines are aria-hidden — the numbers carry the meaning.</p>
+        </div>
+        <div class="demo-preview demo-preview-plain" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); align-items: stretch;">
+          <div class="stat-tile">
+            <div class="stat-tile-header">
+              <div>
+                <div class="stat-tile-label">Open Rate</div>
+                <div class="stat-tile-row">
+                  <span class="stat-tile-value">48.0%</span>
+                  <span class="trend-pill trend-pill-positive"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 10.5 8 5.5 13 10.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>+6.3%</span>
+                </div>
+              </div>
+            </div>
+            <div class="stat-tile-meta">1,234 opens · vs. avg</div>
+            <div class="stat-tile-footer"><div data-sparkline="[38, 42, 40, 45, 43, 48]"></div></div>
+          </div>
+          <div class="stat-tile">
+            <div class="stat-tile-header">
+              <div>
+                <div class="stat-tile-label">Bounce Rate</div>
+                <div class="stat-tile-row">
+                  <span class="stat-tile-value">6.2%</span>
+                  <span class="status-badge status-badge-warning" role="status"><span aria-hidden="true">⚠</span> High</span>
+                </div>
+              </div>
+            </div>
+            <div class="stat-tile-meta">67 bounced · vs. avg</div>
+            <div class="stat-tile-footer"><div data-sparkline="[3.1, 3.4, 4.2, 4.0, 5.1, 6.2]"></div></div>
+          </div>
+          <div class="stat-tile">
+            <div class="stat-tile-header">
+              <div>
+                <div class="stat-tile-label">Subscribers</div>
+                <div class="stat-tile-row"><span class="stat-tile-value">2,568</span></div>
+              </div>
+              <span class="stat-tile-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+            </div>
+            <div class="stat-tile-meta">+41 this week</div>
+            <div class="stat-tile-footer"><div data-sparkline="[2381, 2402, 2445, 2489, 2527, 2568]"></div></div>
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { StatTile } from '@readysetcloud/ui';
+
+&lt;StatTile
+  label="Open Rate"
+  value="48.0%"
+  delta={6.3}
+  meta="1,234 opens · vs. avg"
+  sparkline={[38, 42, 40, 45, 43, 48]}
+/&gt;
+
+&lt;StatTile
+  label="Bounce Rate"
+  value="6.2%"
+  delta={-0.4}
+  invertDelta               // falling bounce = improvement
+  status={{ tone: 'warning', label: 'High' }}
+  meta="67 bounced · vs. avg"
+  sparkline={[3.1, 3.4, 4.2, 4.0, 5.1, 6.2]}
+/&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="stat-tile"&gt;
+  &lt;div class="stat-tile-header"&gt;
+    &lt;div&gt;
+      &lt;div class="stat-tile-label"&gt;Open Rate&lt;/div&gt;
+      &lt;div class="stat-tile-row"&gt;
+        &lt;span class="stat-tile-value"&gt;48.0%&lt;/span&gt;
+        &lt;span class="trend-pill trend-pill-positive"&gt;+6.3%&lt;/span&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class="stat-tile-meta"&gt;1,234 opens · vs. avg&lt;/div&gt;
+  &lt;div class="stat-tile-footer"&gt;&lt;div id="opens-trend"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;/div&gt;
+&lt;script&gt;
+  // window.rscUi from ui.global.js
+  rscUi.renderSparkline(
+    document.getElementById('opens-trend'),
+    [38, 42, 40, 45, 43, 48]
+  );
+&lt;/script&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="hero">
+      <span class="ds-kicker">Layout</span>
+      <h2>Page hero</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>PageHero</h3>
+          <p>The gradient band that opens a page: surface-to-primary wash, blurred accent blob (drawn in CSS — no extra markup), display-font title, and pill meta chips.</p>
+        </div>
+        <div class="demo-preview demo-preview-stack demo-preview-plain">
+          <header class="page-hero">
+            <div class="page-hero-content">
+              <h1 class="page-hero-title" style="font-size: 1.5rem;">Serverless Picks of the Week #204</h1>
+              <p class="page-hero-subtitle">Sent to your loyal readers, tracked end to end.</p>
+              <div class="page-hero-chips">
+                <span class="page-hero-chip">Issue #204</span>
+                <span class="page-hero-chip">Created Jul 18</span>
+                <span class="page-hero-chip page-hero-chip-success">Sent Jul 21</span>
+                <span class="page-hero-chip">2,568 recipients</span>
+              </div>
+            </div>
+          </header>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import {
+  PageHero, PageHeroTitle, PageHeroSubtitle, PageHeroChips, PageHeroChip
+} from '@readysetcloud/ui';
+
+&lt;PageHero&gt;
+  &lt;PageHeroTitle&gt;Serverless Picks of the Week #204&lt;/PageHeroTitle&gt;
+  &lt;PageHeroSubtitle&gt;Sent to your loyal readers, tracked end to end.&lt;/PageHeroSubtitle&gt;
+  &lt;PageHeroChips&gt;
+    &lt;PageHeroChip&gt;Issue #204&lt;/PageHeroChip&gt;
+    &lt;PageHeroChip tone="success"&gt;Sent Jul 21&lt;/PageHeroChip&gt;
+  &lt;/PageHeroChips&gt;
+&lt;/PageHero&gt;</code></pre>
+<pre data-lang="html"><code>&lt;header class="page-hero"&gt;
+  &lt;div class="page-hero-content"&gt;
+    &lt;h1 class="page-hero-title"&gt;Serverless Picks of the Week #204&lt;/h1&gt;
+    &lt;p class="page-hero-subtitle"&gt;Sent to your loyal readers.&lt;/p&gt;
+    &lt;div class="page-hero-chips"&gt;
+      &lt;span class="page-hero-chip"&gt;Issue #204&lt;/span&gt;
+      &lt;span class="page-hero-chip page-hero-chip-success"&gt;Sent Jul 21&lt;/span&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/header&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="cards">
+      <span class="ds-kicker">Layout</span>
+      <h2>Cards</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Card</h3>
+          <p>The compound container behind most content: header, title, description, body, footer.</p>
+        </div>
+        <div class="demo-preview demo-preview-stack demo-preview-plain">
+          <div class="card" style="max-width: 26rem;">
+            <div class="card-header">
+              <h3 class="card-title">Sending health</h3>
+              <p class="card-description">Deliverability signals for the last 10 issues.</p>
+            </div>
+            <div class="card-body">Bounce, complaint, and unsubscribe rates are all inside their thresholds.</div>
+            <div class="card-footer"><button class="btn btn-ghost btn-sm" type="button">View details</button></div>
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Card, CardHeader, CardTitle, CardDescription, CardBody, CardFooter } from '@readysetcloud/ui';
+
+&lt;Card&gt;
+  &lt;CardHeader&gt;
+    &lt;CardTitle&gt;Sending health&lt;/CardTitle&gt;
+    &lt;CardDescription&gt;Deliverability signals.&lt;/CardDescription&gt;
+  &lt;/CardHeader&gt;
+  &lt;CardBody&gt;…&lt;/CardBody&gt;
+  &lt;CardFooter&gt;…&lt;/CardFooter&gt;
+&lt;/Card&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="card"&gt;
+  &lt;div class="card-header"&gt;
+    &lt;h3 class="card-title"&gt;Sending health&lt;/h3&gt;
+    &lt;p class="card-description"&gt;Deliverability signals.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;div class="card-body"&gt;…&lt;/div&gt;
+  &lt;div class="card-footer"&gt;…&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="forms">
+      <span class="ds-kicker">Input</span>
+      <h2>Forms</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Fields</h3>
+          <p>Label/aria wiring is automatic in React. Inputs hold ≥16px text on mobile (no iOS zoom) and show the azure focus ring.</p>
+        </div>
+        <div class="demo-preview demo-preview-plain" style="align-items: flex-start;">
+          <div class="field" style="min-width: 16rem;">
+            <label class="field-label" for="ds-email">Email address</label>
+            <input class="input" id="ds-email" type="email" placeholder="you@readysetcloud.io">
+            <span class="field-hint">We'll never share it.</span>
+          </div>
+          <div class="field" style="min-width: 16rem;">
+            <label class="field-label" for="ds-name">Newsletter name</label>
+            <input class="input input-error" id="ds-name" value="">
+            <span class="field-error" role="alert">A name is required.</span>
+          </div>
+          <div class="field" style="min-width: 12rem;">
+            <label class="field-label" for="ds-tier">Tier</label>
+            <select class="input" id="ds-tier"><option>Free</option><option>Creator</option><option>Pro</option></select>
+          </div>
+          <div class="field" style="min-width: 10rem;">
+            <label class="field-label" for="ds-code">Verification code</label>
+            <input class="input input-code" id="ds-code" inputmode="numeric" maxlength="6" placeholder="••••••">
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Input, Select, CodeInput } from '@readysetcloud/ui';
+
+&lt;Input label="Email address" type="email" hint="We'll never share it." /&gt;
+&lt;Input label="Newsletter name" error="A name is required." /&gt;
+&lt;Select label="Tier"&gt;&lt;option&gt;Free&lt;/option&gt;&lt;/Select&gt;
+&lt;CodeInput label="Verification code" /&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="field"&gt;
+  &lt;label class="field-label" for="email"&gt;Email address&lt;/label&gt;
+  &lt;input class="input" id="email" type="email"&gt;
+  &lt;span class="field-hint"&gt;We'll never share it.&lt;/span&gt;
+&lt;/div&gt;
+
+&lt;input class="input input-error"&gt;
+&lt;span class="field-error" role="alert"&gt;A name is required.&lt;/span&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="feedback">
+      <span class="ds-kicker">Feedback</span>
+      <h2>Alerts, toasts &amp; modals</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Alert</h3>
+          <p>Inline outcome messaging. Error alerts get <code>role="alert"</code>.</p>
+        </div>
+        <div class="demo-preview demo-preview-stack demo-preview-plain">
+          <div class="alert alert-success">Issue #204 scheduled for Monday 9:00 AM.</div>
+          <div class="alert alert-info">Your sender domain is pending DNS verification.</div>
+          <div class="alert alert-error" role="alert">We couldn't reach SendGrid. Try again in a minute.</div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Alert } from '@readysetcloud/ui';
+
+&lt;Alert variant="success"&gt;Issue #204 scheduled.&lt;/Alert&gt;
+&lt;Alert variant="error"&gt;We couldn't reach SendGrid.&lt;/Alert&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="alert alert-success"&gt;Issue #204 scheduled.&lt;/div&gt;
+&lt;div class="alert alert-error" role="alert"&gt;We couldn't reach SendGrid.&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Toast</h3>
+          <p>Transient confirmations, bottom-right (full-width on phones). Mount <code>ToastProvider</code> once; errors linger 8s, others 5s.</p>
+        </div>
+        <div class="demo-preview demo-preview-plain" style="align-items: flex-start;">
+          <div class="toast toast-success" style="position: static;">Subscriber imported.</div>
+          <div class="toast toast-error" style="position: static;">Import failed — bad CSV header.</div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { ToastProvider, useToast } from '@readysetcloud/ui';
+
+const { toast } = useToast();
+toast('Subscriber imported.', { variant: 'success' });</code></pre>
+<pre data-lang="html"><code>&lt;div class="toast-viewport"&gt;
+  &lt;div class="toast toast-success"&gt;Subscriber imported.&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Modal</h3>
+          <p>Native <code>&lt;dialog&gt;</code> — Esc/backdrop close and focus trapping for free. Becomes a bottom sheet on small screens.</p>
+        </div>
+        <div class="demo-preview">
+          <button class="btn btn-primary" type="button" data-open-modal="ds-demo-modal">Open modal</button>
+          <dialog class="modal" id="ds-demo-modal" aria-label="Delete issue">
+            <div style="padding: 1.25rem; display: flex; flex-direction: column; gap: 0.75rem;">
+              <h3 class="card-title">Delete issue #204?</h3>
+              <p style="margin: 0; font-size: 0.875rem; color: rgb(var(--muted-foreground));">This can't be undone. Subscribers who already received it are unaffected.</p>
+              <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
+                <form method="dialog"><button class="btn btn-secondary" type="submit">Cancel</button></form>
+                <form method="dialog"><button class="btn btn-error" type="submit">Delete</button></form>
+              </div>
+            </div>
+          </dialog>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { Modal } from '@readysetcloud/ui';
+
+&lt;Modal open={open} onClose={() =&gt; setOpen(false)} aria-label="Delete issue"&gt;
+  …
+&lt;/Modal&gt;</code></pre>
+<pre data-lang="html"><code>&lt;dialog class="modal" id="confirm" aria-label="Delete issue"&gt;…&lt;/dialog&gt;
+&lt;script&gt;document.getElementById('confirm').showModal();&lt;/script&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="loading">
+      <span class="ds-kicker">Waiting</span>
+      <h2>Loading &amp; empty states</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Spinner, skeleton, progress</h3>
+          <p>Use the composed loading states from the package instead of app-local loaders.</p>
+        </div>
+        <div class="demo-preview demo-preview-plain" style="align-items: flex-start; gap: 2rem;">
+          <div class="inline-loading"><span class="spinner"></span> <span class="loading-state-text">Sending…</span></div>
+          <div style="display: flex; flex-direction: column; gap: 0.5rem; min-width: 12rem;">
+            <div class="skeleton" style="width: 100%; height: 1rem;"></div>
+            <div class="skeleton" style="width: 75%; height: 1rem;"></div>
+            <div class="skeleton" style="width: 50%; height: 1rem;"></div>
+          </div>
+          <div class="progress-indicator">
+            <div class="progress-step" data-status="completed"><span class="progress-step-icon"></span><span class="progress-step-copy"><span class="progress-step-label">Domain added</span></span></div>
+            <div class="progress-step" data-status="in-progress"><span class="progress-step-icon"></span><span class="progress-step-copy"><span class="progress-step-label">DNS propagating</span></span></div>
+            <div class="progress-step" data-status="pending"><span class="progress-step-icon"></span><span class="progress-step-copy"><span class="progress-step-label">Send test email</span></span></div>
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { InlineLoading, Skeleton, ProgressIndicator } from '@readysetcloud/ui';
+
+&lt;InlineLoading isLoading loadingText="Sending…" /&gt;
+&lt;Skeleton width="75%" /&gt;
+&lt;ProgressIndicator steps={[
+  { id: 'domain', label: 'Domain added', status: 'completed' },
+  { id: 'dns', label: 'DNS propagating', status: 'in-progress' },
+  { id: 'test', label: 'Send test email', status: 'pending' }
+]} /&gt;</code></pre>
+<pre data-lang="html"><code>&lt;span class="spinner"&gt;&lt;/span&gt;
+&lt;div class="skeleton" style="width: 75%; height: 1rem;"&gt;&lt;/div&gt;
+&lt;div class="progress-step" data-status="completed"&gt;…&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>EmptyState</h3>
+        </div>
+        <div class="demo-preview demo-preview-stack demo-preview-plain">
+          <div class="card">
+            <div class="empty-state">
+              <span style="font-size: 2rem;" aria-hidden="true">📭</span>
+              <span class="empty-state-title">No issues yet</span>
+              <span>Write your first issue and it will show up here.</span>
+              <button class="btn btn-primary btn-sm" type="button">New issue</button>
+            </div>
+          </div>
+        </div>
+        <div class="demo-code">
+<pre data-lang="react"><code>import { EmptyState, Button } from '@readysetcloud/ui';
+
+&lt;EmptyState
+  title="No issues yet"
+  description="Write your first issue and it will show up here."
+  icon="📭"
+  action={&lt;Button size="sm"&gt;New issue&lt;/Button&gt;}
+/&gt;</code></pre>
+<pre data-lang="html"><code>&lt;div class="empty-state"&gt;
+  &lt;span class="empty-state-title"&gt;No issues yet&lt;/span&gt;
+  &lt;span&gt;Write your first issue and it will show up here.&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="navigation">
+      <span class="ds-kicker">Chrome</span>
+      <h2>App navigation</h2>
+      <p class="ds-lede">
+        The navbar at the top of this page <em>is</em> the shared <code>AppNav</code> markup —
+        branded cloud mark, Raleway app name, theme toggle. React apps get the typed component
+        (with the 9-box launcher, auth controls, and a <code>layout="side"</code> rail);
+        vanilla pages mount the same thing via <code>window.rscNav</code>. The
+        <code>BadgeChest</code> gamification chest ships here too. See
+        <a href="https://github.com/readysetcloud/rsc-core/blob/main/ui/AGENTS.md">AGENTS.md</a>
+        for the full navbar and badge API.
+      </p>
+      <div class="demo">
+        <div class="demo-code">
+<pre data-lang="react"><code>import { AppNav, readySetCloudServices } from '@readysetcloud/ui';
+
+&lt;AppNav
+  appName="Outboxed"
+  currentServiceId="outboxed"
+  authState={signedIn ? 'authenticated' : 'anonymous'}
+  navItems={[{ id: 'dashboard', label: 'Dashboard', href: '/dashboard', active: true }]}
+  services={readySetCloudServices}
+/&gt;</code></pre>
+<pre data-lang="html"><code>&lt;script src="https://&lt;assets-host&gt;/ui/latest/nav.global.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+  rscNav.mountAppNav(document.getElementById('nav'), { appName: 'Bootcamp', … });
+&lt;/script&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="ds-footer">
+    <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
+    <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+  </footer>
+
+  <script src="ui/dist/ui.global.js"></script>
+  <script src="site.js"></script>
+</body>
+</html>

--- a/design-system/foundations.html
+++ b/design-system/foundations.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Foundations · Ready, Set, Cloud Design System</title>
+  <meta name="description" content="Color, typography, shape, and elevation — the token layer of the Ready, Set, Cloud design system, rendered live from the shipped stylesheet.">
+  <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
+  <link rel="stylesheet" href="ui/styles/fonts.css">
+  <link rel="stylesheet" href="ui/styles/index.css">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <nav class="app-nav">
+    <div class="app-nav-inner">
+      <a class="app-nav-brand" href="index.html">
+        <span class="app-nav-brand-mark"></span>
+        <span class="app-nav-brand-name">Ready, Set, Cloud</span>
+      </a>
+      <button class="app-nav-menu-btn" type="button" aria-label="Toggle navigation">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3zm0 5h18v2H3zm0 5h18v2H3z"/></svg>
+      </button>
+      <div class="app-nav-collapse">
+        <div class="app-nav-links">
+          <a class="app-nav-link" href="index.html">Overview</a>
+          <a class="app-nav-link app-nav-link-active" href="foundations.html">Foundations</a>
+          <a class="app-nav-link" href="components.html">Components</a>
+          <a class="app-nav-link" href="patterns.html">Patterns</a>
+        </div>
+        <div class="app-nav-actions">
+          <a class="app-nav-icon-btn" href="https://github.com/readysetcloud/rsc-core" aria-label="rsc-core on GitHub">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          </a>
+          <button class="app-nav-icon-btn" type="button" data-theme-toggle aria-label="Toggle light and dark theme">
+            <svg class="theme-icon-light" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1M12 1v3M12 20v3M1 12h3M20 12h3" stroke="currentColor" stroke-width="2"/></svg>
+            <svg class="theme-icon-dark" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="ds-shell">
+    <header class="page-hero">
+      <div class="page-hero-content">
+        <span class="ds-kicker">Foundations</span>
+        <h1 class="page-hero-title">The token layer</h1>
+        <p class="page-hero-subtitle">
+          Every visual decision resolves to a CSS custom property in
+          <code>ui/styles/tokens.css</code>. The swatches and specimens on this page are read
+          live from that stylesheet — toggle the theme and watch the ramps invert.
+        </p>
+        <div class="page-hero-chips">
+          <span class="page-hero-chip page-hero-chip-primary">#219EFF azure</span>
+          <span class="page-hero-chip">RGB triplets for alpha</span>
+          <span class="page-hero-chip">50–950 ramps</span>
+        </div>
+      </div>
+    </header>
+
+    <ul class="ds-anchor-list">
+      <li><a href="#color">Color</a></li>
+      <li><a href="#typography">Typography</a></li>
+      <li><a href="#shape">Shape</a></li>
+      <li><a href="#elevation">Elevation</a></li>
+    </ul>
+
+    <section class="ds-section" id="color">
+      <span class="ds-kicker">Color</span>
+      <h2>Palette</h2>
+      <p class="ds-lede">
+        Colors are stored as RGB triplets so consumers can apply alpha:
+        <code>rgb(var(--primary-500))</code> or <code>rgb(var(--primary-500) / 0.16)</code>.
+        Each ramp runs 50–950 and <strong>auto-inverts in dark mode</strong> — 100 flips dark,
+        900 flips light — so a single token class is correct in both themes.
+        Click any swatch to copy its <code>rgb(var(…))</code> form.
+      </p>
+
+      <div class="ramp">
+        <h3>Ground</h3>
+        <p class="ramp-note">Azure-biased neutrals that everything sits on. <code>--surface</code> is the card plane, <code>--background</code> the page.</p>
+        <div class="ground-grid" data-ground-tokens></div>
+      </div>
+
+      <div class="ramp">
+        <h3>Primary — azure</h3>
+        <p class="ramp-note">Generated from the marketing azure <code>#219EFF</code>; 500 is the brand hex. Actions, focus, links, brand moments.</p>
+        <div class="ramp-row" data-ramp="primary"></div>
+      </div>
+
+      <div class="ramp">
+        <h3>Secondary — slate</h3>
+        <p class="ramp-note">Quiet structure: secondary buttons, dividers, de-emphasized text.</p>
+        <div class="ramp-row" data-ramp="secondary"></div>
+      </div>
+
+      <div class="ramp">
+        <h3>Success — teal</h3>
+        <p class="ramp-note">Positive outcomes, healthy states, improving trends.</p>
+        <div class="ramp-row" data-ramp="success"></div>
+      </div>
+
+      <div class="ramp">
+        <h3>Warning — orange</h3>
+        <p class="ramp-note">Caution, thresholds approached, degraded-but-working.</p>
+        <div class="ramp-row" data-ramp="warning"></div>
+      </div>
+
+      <div class="ramp">
+        <h3>Error — deep red</h3>
+        <p class="ramp-note">Failures and destructive actions. Deliberately darkened around <code>#C81E22</code> — a move off the old rose.</p>
+        <div class="ramp-row" data-ramp="error"></div>
+      </div>
+
+      <div class="ds-note">
+        Adding a color? New ramps must follow the convention: full 50–950 scale, plus the
+        dark-mode inversion, defined in <code>tokens.css</code> in the same change. See
+        <a href="patterns.html#dark-mode">the dark-mode pattern</a> for why.
+      </div>
+    </section>
+
+    <section class="ds-section" id="typography">
+      <span class="ds-kicker">Typography</span>
+      <h2>Three faces, one wordmark</h2>
+      <p class="ds-lede">Each face has one job. If text is a heading it's Sora; if it's data it's JetBrains Mono; everything else is Manrope.</p>
+      <div class="ds-grid ds-grid-wide">
+        <div class="type-card">
+          <p class="type-sample" style="font-family: var(--font-display); font-weight: 700;">Sora carries the headline.</p>
+          <p class="type-meta"><span>--font-display</span><span>headings · display values · card titles</span></p>
+        </div>
+        <div class="type-card">
+          <p class="type-sample" style="font-family: var(--font-sans); font-size: 1.125rem; line-height: 1.6;">Manrope carries the reading: body copy, labels, navigation, and everything conversational in the interface.</p>
+          <p class="type-meta"><span>--font-sans</span><span>body · UI text · labels</span></p>
+        </div>
+        <div class="type-card">
+          <p class="type-sample" style="font-family: var(--font-mono); font-size: 1.25rem;">1,024 sent · 98.7%</p>
+          <p class="type-meta"><span>--font-mono</span><span>data · code · badges</span></p>
+        </div>
+        <div class="type-card">
+          <p class="type-sample" style="font-family: var(--font-logo); font-weight: 800;">Ready, Set, Cloud</p>
+          <p class="type-meta"><span>--font-logo (Raleway)</span><span>wordmark lockups ONLY — never UI text</span></p>
+        </div>
+      </div>
+
+      <div class="type-scale">
+        <div class="type-scale-row"><span class="type-scale-label">display / 30</span><span style="font-family: var(--font-display); font-size: 1.875rem; font-weight: 700;">Page hero title</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">display / 22</span><span style="font-family: var(--font-display); font-size: 1.375rem; font-weight: 700;">Section heading</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">display / 16</span><span style="font-family: var(--font-display); font-size: 1rem; font-weight: 700;">Card title</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">sans / 15</span><span style="font-size: 0.9375rem;">Primary body and nav labels</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">sans / 13</span><span style="font-size: 0.8125rem; color: rgb(var(--muted-foreground));">Secondary copy, hints, captions</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">sans / 11 caps</span><span class="stat-tile-label">Stat tile label</span></div>
+        <div class="type-scale-row"><span class="type-scale-label">mono / 11 caps</span><span class="badge badge-primary">Badge</span></div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="shape">
+      <span class="ds-kicker">Shape</span>
+      <h2>Radius</h2>
+      <p class="ds-lede">Sharper than the old app look, not fully square. Inputs and buttons sit at the 4px default; cards step up; pills go full.</p>
+      <div class="demo-preview demo-preview-plain" style="border: 0; padding: 0; margin-top: 1.25rem; gap: 1.5rem;">
+        <div><div class="radius-specimen" style="border-radius: var(--radius-sm);"></div><p class="specimen-label">--radius-sm · 2px</p></div>
+        <div><div class="radius-specimen" style="border-radius: var(--radius);"></div><p class="specimen-label">--radius · 4px</p></div>
+        <div><div class="radius-specimen" style="border-radius: var(--radius-lg);"></div><p class="specimen-label">--radius-lg · 6px</p></div>
+        <div><div class="radius-specimen" style="border-radius: var(--radius-xl);"></div><p class="specimen-label">--radius-xl · 8px</p></div>
+        <div><div class="radius-specimen" style="border-radius: var(--radius-full); width: 5rem;"></div><p class="specimen-label">--radius-full · pill</p></div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="elevation">
+      <span class="ds-kicker">Elevation</span>
+      <h2>Shadows</h2>
+      <p class="ds-lede">Three steps, all tinted with the ink color. Cards rest at soft, lift to medium on hover; modals float at large.</p>
+      <div class="demo-preview demo-preview-plain" style="border: 0; padding: 1rem 0; margin-top: 1.25rem; gap: 1.5rem;">
+        <div><div class="shadow-specimen" style="box-shadow: var(--shadow-soft);">--shadow-soft</div><p class="specimen-label">cards at rest</p></div>
+        <div><div class="shadow-specimen" style="box-shadow: var(--shadow-medium);">--shadow-medium</div><p class="specimen-label">hover · toasts</p></div>
+        <div><div class="shadow-specimen" style="box-shadow: var(--shadow-large);">--shadow-large</div><p class="specimen-label">modals</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="ds-footer">
+    <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
+    <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+  </footer>
+
+  <script src="ui/dist/ui.global.js"></script>
+  <script src="site.js"></script>
+</body>
+</html>

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ready, Set, Cloud Design System</title>
+  <meta name="description" content="The shared design system behind every Ready, Set, Cloud surface — tokens, components, and patterns, rendered from the @readysetcloud/ui package itself.">
+  <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
+  <link rel="stylesheet" href="ui/styles/fonts.css">
+  <link rel="stylesheet" href="ui/styles/index.css">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <nav class="app-nav">
+    <div class="app-nav-inner">
+      <a class="app-nav-brand" href="index.html">
+        <span class="app-nav-brand-mark"></span>
+        <span class="app-nav-brand-name">Ready, Set, Cloud</span>
+      </a>
+      <button class="app-nav-menu-btn" type="button" aria-label="Toggle navigation">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3zm0 5h18v2H3zm0 5h18v2H3z"/></svg>
+      </button>
+      <div class="app-nav-collapse">
+        <div class="app-nav-links">
+          <a class="app-nav-link app-nav-link-active" href="index.html">Overview</a>
+          <a class="app-nav-link" href="foundations.html">Foundations</a>
+          <a class="app-nav-link" href="components.html">Components</a>
+          <a class="app-nav-link" href="patterns.html">Patterns</a>
+        </div>
+        <div class="app-nav-actions">
+          <a class="app-nav-icon-btn" href="https://github.com/readysetcloud/rsc-core" aria-label="rsc-core on GitHub">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          </a>
+          <button class="app-nav-icon-btn" type="button" data-theme-toggle aria-label="Toggle light and dark theme">
+            <svg class="theme-icon-light" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1h0v3h0zM12 20h0v3h0zM1 12h3v0h0zM20 12h3v0h0z" stroke="currentColor" stroke-width="2"/><path d="M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1" stroke="currentColor" stroke-width="2"/></svg>
+            <svg class="theme-icon-dark" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="ds-shell">
+    <header class="page-hero">
+      <div class="page-hero-content">
+        <span class="ds-kicker">@readysetcloud/ui</span>
+        <h1 class="page-hero-title">One brand. Every surface.</h1>
+        <p class="page-hero-subtitle">
+          The design system behind Ready, Set, Cloud — a single npm package of tokens,
+          components, and auth that keeps the newsletter dashboard, the bootcamp platform,
+          and readysetcloud.io looking and behaving like one product.
+        </p>
+        <div class="page-hero-chips">
+          <span class="page-hero-chip page-hero-chip-primary">Token-driven</span>
+          <span class="page-hero-chip page-hero-chip-success">Light + dark for free</span>
+          <span class="page-hero-chip">React <em>and</em> plain CSS</span>
+          <span class="page-hero-chip">WCAG-minded</span>
+        </div>
+      </div>
+    </header>
+
+    <div class="ds-note">
+      This guide is rendered with the package's <em>own</em> stylesheets and browser bundles —
+      the swatches, specimens, and demos below read live values straight from
+      <code>ui/styles</code>, so the guide can never drift from the shipped system.
+    </div>
+
+    <section class="ds-section">
+      <span class="ds-kicker">Philosophy</span>
+      <h2>Principles</h2>
+      <p class="ds-lede">Six rules keep three very different codebases converged on one brand.</p>
+      <div class="ds-grid">
+        <div class="ds-link-card">
+          <h3>One source of truth</h3>
+          <p>Brand, components, and auth live in <code>rsc-core/ui</code> and nowhere else. Never fork or copy — change it here, version it, consume it.</p>
+        </div>
+        <div class="ds-link-card">
+          <h3>Tokens, not hex</h3>
+          <p>No app hardcodes a brand color. Everything goes through <code>rgb(var(--primary-600))</code>, the Tailwind preset scales, or the shipped classes.</p>
+        </div>
+        <div class="ds-link-card">
+          <h3>Both themes for free</h3>
+          <p>The token ramps auto-invert in dark mode. Use a single token class and both themes are correct — never stack <code>dark:</code> overrides on token colors.</p>
+        </div>
+        <div class="ds-link-card">
+          <h3>Framework-optional</h3>
+          <p>Every component ships twice: a typed React component and the plain CSS class it renders. Hugo pages and vanilla JS get pixel-identical UI.</p>
+        </div>
+        <div class="ds-link-card">
+          <h3>Accessible by default</h3>
+          <p>44px touch targets, ≥16px mobile inputs, visible keyboard focus, aria wiring baked into components. Don't override these down.</p>
+        </div>
+        <div class="ds-link-card">
+          <h3>Typography with intent</h3>
+          <p>Sora for headings, Manrope for body, JetBrains Mono for data. Raleway is the wordmark face <em>only</em> — never UI text.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section">
+      <span class="ds-kicker">Reach</span>
+      <h2>The surfaces</h2>
+      <p class="ds-lede">Every Ready, Set, Cloud property consumes this package — each in the way that fits its stack.</p>
+      <div class="ds-table-wrap">
+        <table class="ds-table">
+          <thead>
+            <tr><th>Surface</th><th>Stack</th><th>Consumes via</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Newsletter dashboard (Outboxed)</td><td>React SPA</td><td><code>npm i @readysetcloud/ui</code></td></tr>
+            <tr><td>Concurrency bootcamp platform</td><td>React SPA</td><td><code>npm i @readysetcloud/ui</code></td></tr>
+            <tr><td>Bootcamp course pages</td><td>Vanilla JS</td><td>hosted <code>auth.global.js</code> / <code>nav.global.js</code> / <code>ui.global.js</code></td></tr>
+            <tr><td>readysetcloud.io</td><td>Hugo</td><td>hosted <code>styles/*.css</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ds-section">
+      <span class="ds-kicker">Quick start</span>
+      <h2>Get started</h2>
+      <p class="ds-lede">React apps install from npm; everything else links the hosted assets published on every rsc-core deploy.</p>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>React apps</h3>
+          <p>Import the stylesheet once before app styles, and adopt the Tailwind preset so utility classes resolve to tokens.</p>
+        </div>
+        <div class="demo-code">
+<pre data-lang="shell"><code>npm install @readysetcloud/ui</code></pre>
+<pre data-lang="tsx"><code>// main.tsx — ALWAYS import the stylesheet once, before app styles
+import '@readysetcloud/ui/styles.css';
+import '@readysetcloud/ui/fonts.css'; // if the app doesn't load brand fonts itself
+
+// tailwind.config.js
+module.exports = {
+  presets: [require('@readysetcloud/ui/tailwind-preset')],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    './node_modules/@readysetcloud/ui/dist/**/*.js' // REQUIRED
+  ]
+};</code></pre>
+        </div>
+      </div>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Everything else</h3>
+          <p>Link the hosted assets. <code>ui/&lt;version&gt;/</code> paths are immutable; <code>ui/latest/</code> is a five-minute pointer.</p>
+        </div>
+        <div class="demo-code">
+<pre data-lang="html"><code>&lt;link rel="stylesheet" href="https://&lt;assets-host&gt;/ui/latest/styles/index.css"&gt;
+&lt;script src="https://&lt;assets-host&gt;/ui/latest/auth.global.js"&gt;&lt;/script&gt;  &lt;!-- window.rscAuth --&gt;
+&lt;script src="https://&lt;assets-host&gt;/ui/latest/nav.global.js"&gt;&lt;/script&gt;   &lt;!-- window.rscNav --&gt;
+&lt;script src="https://&lt;assets-host&gt;/ui/latest/ui.global.js"&gt;&lt;/script&gt;    &lt;!-- window.rscUi --&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section">
+      <span class="ds-kicker">Dive in</span>
+      <h2>Explore the system</h2>
+      <div class="ds-grid ds-grid-wide">
+        <a class="ds-link-card" href="foundations.html">
+          <h3>Foundations</h3>
+          <p>The azure palette and its ramps, the three-face type system, shape, and elevation — read live from the tokens.</p>
+          <span class="ds-card-arrow">Colors, type, shape →</span>
+        </a>
+        <a class="ds-link-card" href="components.html">
+          <h3>Components</h3>
+          <p>Live, theme-aware demos of every shipped component with side-by-side React and plain-HTML usage.</p>
+          <span class="ds-card-arrow">Buttons to stat tiles →</span>
+        </a>
+        <a class="ds-link-card" href="patterns.html">
+          <h3>Patterns</h3>
+          <p>Dark mode and the token auto-inversion rule, the responsive contract, and how each surface consumes the system.</p>
+          <span class="ds-card-arrow">Rules of the road →</span>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="ds-footer">
+    <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
+    <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+  </footer>
+
+  <script src="ui/dist/ui.global.js"></script>
+  <script src="site.js"></script>
+</body>
+</html>

--- a/design-system/patterns.html
+++ b/design-system/patterns.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Patterns · Ready, Set, Cloud Design System</title>
+  <meta name="description" content="Dark mode and the token auto-inversion rule, the responsive contract, and how each Ready, Set, Cloud surface consumes the design system.">
+  <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
+  <link rel="stylesheet" href="ui/styles/fonts.css">
+  <link rel="stylesheet" href="ui/styles/index.css">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <nav class="app-nav">
+    <div class="app-nav-inner">
+      <a class="app-nav-brand" href="index.html">
+        <span class="app-nav-brand-mark"></span>
+        <span class="app-nav-brand-name">Ready, Set, Cloud</span>
+      </a>
+      <button class="app-nav-menu-btn" type="button" aria-label="Toggle navigation">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3zm0 5h18v2H3zm0 5h18v2H3z"/></svg>
+      </button>
+      <div class="app-nav-collapse">
+        <div class="app-nav-links">
+          <a class="app-nav-link" href="index.html">Overview</a>
+          <a class="app-nav-link" href="foundations.html">Foundations</a>
+          <a class="app-nav-link" href="components.html">Components</a>
+          <a class="app-nav-link app-nav-link-active" href="patterns.html">Patterns</a>
+        </div>
+        <div class="app-nav-actions">
+          <a class="app-nav-icon-btn" href="https://github.com/readysetcloud/rsc-core" aria-label="rsc-core on GitHub">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          </a>
+          <button class="app-nav-icon-btn" type="button" data-theme-toggle aria-label="Toggle light and dark theme">
+            <svg class="theme-icon-light" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1M12 1v3M12 20v3M1 12h3M20 12h3" stroke="currentColor" stroke-width="2"/></svg>
+            <svg class="theme-icon-dark" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="ds-shell">
+    <header class="page-hero">
+      <div class="page-hero-content">
+        <span class="ds-kicker">Patterns</span>
+        <h1 class="page-hero-title">Rules of the road</h1>
+        <p class="page-hero-subtitle">
+          The conventions that keep every surface converged — theming, responsiveness,
+          and the right way to consume the system from each stack.
+        </p>
+      </div>
+    </header>
+
+    <ul class="ds-anchor-list">
+      <li><a href="#dark-mode">Dark mode &amp; token inversion</a></li>
+      <li><a href="#tokens">Using tokens</a></li>
+      <li><a href="#responsive">Responsive contract</a></li>
+      <li><a href="#consuming">Consuming the system</a></li>
+      <li><a href="#contributing">Contributing</a></li>
+    </ul>
+
+    <section class="ds-section" id="dark-mode">
+      <span class="ds-kicker">Theming</span>
+      <h2>Dark mode &amp; the token auto-inversion rule</h2>
+      <p class="ds-lede">
+        Dark mode is system-preference by default, with an explicit
+        <code>&lt;html data-theme="dark|light"&gt;</code> override — never a separate theming
+        mechanism. The interesting part is how the palette gets there: <strong>the token ramps
+        invert themselves</strong>. In dark mode <code>--success-100</code> resolves to a deep
+        teal and <code>--success-800</code> to a pale one, so a light-mode recipe like
+        "100 background, 800 text" is automatically correct on a dark ground.
+      </p>
+
+      <div class="demo">
+        <div class="demo-header">
+          <h3>See it live</h3>
+          <p>These pills use <em>single</em> token classes — no <code>dark:</code> anything. Toggle the theme (top right): they stay legible because the ramp flips underneath them.</p>
+        </div>
+        <div class="demo-preview">
+          <span class="status-badge status-badge-success" role="status"><span aria-hidden="true">✓</span> bg-success-100 · text-success-800</span>
+          <span class="status-badge status-badge-warning" role="status"><span aria-hidden="true">⚠</span> bg-warning-100 · text-warning-800</span>
+          <span class="status-badge status-badge-error" role="status"><span aria-hidden="true">✕</span> bg-error-100 · text-error-800</span>
+        </div>
+      </div>
+
+      <p class="ds-lede" style="margin-top: 1.25rem;">
+        The corollary is the most common mistake in app code: <strong>stacking Tailwind
+        <code>dark:</code> variants on token colors double-inverts</strong>. The token already
+        flipped; the <code>dark:</code> override flips it back (or somewhere worse) and washes
+        out contrast. This bit two dashboard components before it became a rule.
+      </p>
+
+      <div class="do-dont">
+        <div class="do">
+          <span class="do-dont-label">Do</span>
+          <pre><code>&lt;span class="bg-success-100 text-success-800"&gt;
+  Stable
+&lt;/span&gt;</code></pre>
+          <p>One token recipe. The ramp inversion makes it correct in both themes.</p>
+        </div>
+        <div class="dont">
+          <span class="do-dont-label">Don't</span>
+          <pre><code>&lt;span class="bg-success-100 text-success-800
+      dark:bg-success-900 dark:text-success-200"&gt;
+  Stable
+&lt;/span&gt;</code></pre>
+          <p>Double inversion. In dark mode this renders pale-on-pale and loses all contrast.</p>
+        </div>
+      </div>
+
+      <div class="ds-note">
+        If a component looks wrong in dark mode, the fix is choosing better token steps —
+        never adding <code>dark:</code>. And when adding a new color, ship both halves:
+        the 50–950 ramp <em>and</em> its dark inversion, in the same change.
+      </div>
+    </section>
+
+    <section class="ds-section" id="tokens">
+      <span class="ds-kicker">Color plumbing</span>
+      <h2>Using tokens</h2>
+      <p class="ds-lede">Tokens are RGB triplets, which keeps alpha compositing in the consumer's hands.</p>
+      <div class="ds-code"><pre><code>/* plain CSS */
+color: rgb(var(--primary-600));
+background: rgb(var(--primary-500) / 0.16);   /* alpha over any ground */
+
+/* Tailwind (preset maps the scales onto tokens) */
+&lt;div class="bg-primary-600 text-primary-50"&gt;
+
+/* the preset also aliases legacy names during migration:
+   blue→primary · green/teal→success · red/rose→error
+   orange/amber/yellow→warning · gray/slate→secondary */</code></pre></div>
+      <div class="ds-note">
+        Never hardcode a brand hex in an app. If you're typing <code>#219EFF</code> anywhere
+        outside <code>tokens.css</code>, stop and use the token.
+      </div>
+    </section>
+
+    <section class="ds-section" id="responsive">
+      <span class="ds-kicker">Small screens</span>
+      <h2>The responsive contract</h2>
+      <p class="ds-lede">Components ship mobile-ready. Apps must not override these down.</p>
+      <div class="ds-grid">
+        <div class="ds-link-card"><h3>44px touch targets</h3><p>Every interactive element hits at least 44×44px on phones — buttons, nav links, icon buttons.</p></div>
+        <div class="ds-link-card"><h3>≥16px mobile inputs</h3><p>Form text never drops below 16px on mobile, which stops iOS focus-zoom.</p></div>
+        <div class="ds-link-card"><h3>Sheets, not floats</h3><p>Modals become full-width bottom sheets ≤640px; toasts span the viewport width.</p></div>
+        <div class="ds-link-card"><h3>Safe areas</h3><p>Fixed chrome pads with <code>env(safe-area-inset-*)</code> for notched devices.</p></div>
+        <div class="ds-link-card"><h3>Fluid type &amp; spacing</h3><p>Heroes and containers use <code>clamp()</code> so layouts scale instead of snapping.</p></div>
+        <div class="ds-link-card"><h3>Focus visibility</h3><p>Keyboard focus is always visible (azure ring); mouse focus stays quiet.</p></div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="consuming">
+      <span class="ds-kicker">Integration</span>
+      <h2>Consuming the system</h2>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>React apps</h3>
+          <p>Install from npm, import the stylesheet once, adopt the Tailwind preset, and import components. Auth (<code>@readysetcloud/ui/auth</code>) and chat (<code>@readysetcloud/ui/chat</code>) live on subpaths so you only pull what you use.</p>
+        </div>
+        <div class="demo-code">
+<pre data-lang="tsx"><code>import '@readysetcloud/ui/styles.css';
+import { AppNav, StatTile, SegmentedControl } from '@readysetcloud/ui';
+import { AuthProvider, useAuth } from '@readysetcloud/ui/auth';</code></pre>
+        </div>
+      </div>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Hugo / static sites</h3>
+          <p>Link the hosted stylesheet — or <code>tokens.css</code> alone to adopt the palette while keeping your own components.</p>
+        </div>
+        <div class="demo-code">
+<pre data-lang="html"><code>&lt;link rel="stylesheet" href="https://&lt;assets-host&gt;/ui/latest/styles/index.css"&gt;
+&lt;!-- or variables only: --&gt;
+&lt;link rel="stylesheet" href="https://&lt;assets-host&gt;/ui/latest/styles/tokens.css"&gt;</code></pre>
+        </div>
+      </div>
+      <div class="demo">
+        <div class="demo-header">
+          <h3>Vanilla JS</h3>
+          <p>Three script-tag globals cover what CSS can't: auth, the shared navbar, and drawing helpers. Everything else — stat tiles, pills, segmented controls, heroes — is just the shipped classes.</p>
+        </div>
+        <div class="demo-code">
+<pre data-lang="html"><code>&lt;script src=".../ui/latest/auth.global.js"&gt;&lt;/script&gt; &lt;!-- window.rscAuth --&gt;
+&lt;script src=".../ui/latest/nav.global.js"&gt;&lt;/script&gt;  &lt;!-- window.rscNav --&gt;
+&lt;script src=".../ui/latest/ui.global.js"&gt;&lt;/script&gt;   &lt;!-- window.rscUi --&gt;
+&lt;script&gt;
+  rscAuth.configureAuth({ region: 'us-east-1', clientId: '…' });
+  rscNav.mountAppNav('#nav', { appName: 'Bootcamp' /* … */ });
+  rscUi.renderSparkline(document.querySelector('#trend'), [38, 42, 45, 48]);
+&lt;/script&gt;</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="ds-section" id="contributing">
+      <span class="ds-kicker">Process</span>
+      <h2>Contributing</h2>
+      <p class="ds-lede">
+        The system only works if it stays the single source of truth. If an app needs a variant
+        that doesn't exist, add it to <code>rsc-core/ui</code> first — never fork a component
+        into an app.
+      </p>
+      <div class="ds-table-wrap">
+        <table class="ds-table">
+          <thead><tr><th>Checklist for changes</th><th>Why</th></tr></thead>
+          <tbody>
+            <tr><td>Keep class names stable</td><td>Apps (and Hugo partials) depend on them directly.</td></tr>
+            <tr><td>Both light <em>and</em> dark values for new tokens</td><td>The auto-inversion contract only holds if every ramp defines both halves.</td></tr>
+            <tr><td>Ship the CSS class with the React component</td><td>React/CSS parity is what keeps vanilla surfaces pixel-identical.</td></tr>
+            <tr><td>Mobile-first (44px targets, ≥16px inputs)</td><td>The responsive contract is part of the component API.</td></tr>
+            <tr><td>Bump <code>version</code> in <code>ui/package.json</code></td><td>Deploy publishes hosted assets under the version; CI publishes to npm when it's new.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="ds-note">
+        This guide deploys from <code>design-system/</code> on every push to <code>main</code>
+        that touches it or the ui package — the workflow rebuilds the package and republishes,
+        so docs and package can't drift.
+      </div>
+    </section>
+  </main>
+
+  <footer class="ds-footer">
+    <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
+    <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+  </footer>
+
+  <script src="ui/dist/ui.global.js"></script>
+  <script src="site.js"></script>
+</body>
+</html>

--- a/design-system/site.css
+++ b/design-system/site.css
@@ -1,0 +1,507 @@
+/*
+ * Design-system guide chrome. Everything brand-visible comes from the ui
+ * package's own stylesheets (ui/styles/index.css) — this file only lays out
+ * the guide itself, on top of the tokens, so the guide restyles itself
+ * whenever the package changes.
+ */
+
+/* ---------- shell ---------- */
+
+.ds-shell {
+  max-width: 72rem;
+  margin-inline: auto;
+  padding: 1.5rem clamp(1rem, 4vw, 2rem) 4rem;
+}
+
+.ds-shell > .page-hero {
+  margin-bottom: 2rem;
+}
+
+.ds-footer {
+  border-top: 1px solid rgb(var(--border));
+  padding: 1.5rem clamp(1rem, 4vw, 2rem);
+  color: rgb(var(--muted-foreground));
+  font-size: 0.8125rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  justify-content: space-between;
+}
+
+.ds-footer a {
+  color: rgb(var(--primary-700));
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.ds-footer a:hover { text-decoration: underline; }
+
+/* ---------- sections ---------- */
+
+.ds-section {
+  margin-top: 3rem;
+  scroll-margin-top: 5rem;
+}
+
+.ds-section > h2 {
+  font-size: 1.375rem;
+  margin: 0 0 0.25rem;
+}
+
+.ds-section > .ds-lede {
+  margin: 0 0 1.25rem;
+  color: rgb(var(--muted-foreground));
+  font-size: 0.9375rem;
+  max-width: 46rem;
+}
+
+.ds-kicker {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--primary-600));
+  margin-bottom: 0.375rem;
+}
+
+/* ---------- cards & grids ---------- */
+
+.ds-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.ds-grid-wide {
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+
+.ds-link-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 1.25rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-soft);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.ds-link-card:hover {
+  border-color: rgb(var(--primary-300));
+  box-shadow: var(--shadow-medium);
+  transform: translateY(-2px);
+}
+
+.ds-link-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.ds-link-card p {
+  margin: 0;
+  color: rgb(var(--muted-foreground));
+  font-size: 0.8125rem;
+}
+
+.ds-link-card .ds-card-arrow {
+  margin-top: auto;
+  padding-top: 0.5rem;
+  color: rgb(var(--primary-600));
+  font-weight: 700;
+  font-size: 0.8125rem;
+}
+
+/* ---------- demos ---------- */
+
+.demo {
+  margin-top: 1.25rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.demo-header {
+  padding: 0.875rem 1.125rem 0;
+}
+
+.demo-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.demo-header p {
+  margin: 0.25rem 0 0;
+  color: rgb(var(--muted-foreground));
+  font-size: 0.8125rem;
+  max-width: 46rem;
+}
+
+.demo-preview {
+  padding: 1.5rem 1.125rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  background:
+    radial-gradient(rgb(var(--border) / 0.55) 1px, transparent 1px) 0 0 / 20px 20px,
+    rgb(var(--background));
+  border-top: 1px solid rgb(var(--border));
+  margin-top: 0.875rem;
+}
+
+.demo-preview-stack {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.demo-preview-plain {
+  background: rgb(var(--background));
+}
+
+/* ---------- code ---------- */
+
+.demo-code {
+  border-top: 1px solid rgb(var(--border));
+  background: rgb(var(--muted) / 0.4);
+}
+
+.demo-code-tabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem 1.125rem 0;
+}
+
+.ds-code,
+.demo-code pre {
+  margin: 0;
+  padding: 1rem 1.125rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.7;
+  color: rgb(var(--foreground));
+  -webkit-text-size-adjust: 100%;
+}
+
+.demo-code pre[hidden] { display: none; }
+
+.ds-code {
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--muted) / 0.4);
+  margin-top: 0.75rem;
+}
+
+.ds-copy {
+  border: 0;
+  background: transparent;
+  color: rgb(var(--muted-foreground));
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+}
+
+.ds-copy:hover { color: rgb(var(--primary-700)); background: rgb(var(--muted)); }
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.8125em;
+  background: rgb(var(--muted));
+  border-radius: var(--radius-sm);
+  padding: 0.125rem 0.3125rem;
+}
+
+pre code { background: transparent; padding: 0; font-size: inherit; }
+
+/* ---------- token swatches ---------- */
+
+.ramp {
+  margin-top: 1.25rem;
+}
+
+.ramp h3 {
+  margin: 0 0 0.125rem;
+  font-size: 0.9375rem;
+}
+
+.ramp .ramp-note {
+  margin: 0 0 0.625rem;
+  color: rgb(var(--muted-foreground));
+  font-size: 0.8125rem;
+}
+
+.ramp-row {
+  display: grid;
+  grid-template-columns: repeat(11, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+.swatch {
+  border: 1px solid rgb(var(--border) / 0.6);
+  border-radius: var(--radius);
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: rgb(var(--surface));
+  font-family: var(--font-mono);
+}
+
+.swatch-chip {
+  height: 3rem;
+}
+
+.swatch-copy {
+  padding: 0.25rem 0.375rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.0625rem;
+  font-size: 0.625rem;
+  color: rgb(var(--muted-foreground));
+  text-align: left;
+}
+
+.swatch-copy strong {
+  color: rgb(var(--foreground));
+  font-weight: 600;
+}
+
+.swatch:hover { border-color: rgb(var(--primary-400)); }
+
+.ground-grid {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 720px) {
+  .ramp-row { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+}
+
+/* ---------- typography specimens ---------- */
+
+.type-card {
+  padding: 1.25rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-soft);
+}
+
+.type-card .type-sample {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  margin: 0 0 0.75rem;
+}
+
+.type-card .type-meta {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: rgb(var(--muted-foreground));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  margin: 0;
+}
+
+.type-scale {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.type-scale-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  border-bottom: 1px dashed rgb(var(--border));
+  padding-bottom: 0.75rem;
+}
+
+.type-scale-row .type-scale-label {
+  flex: 0 0 8rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: rgb(var(--muted-foreground));
+}
+
+/* ---------- shape & elevation ---------- */
+
+.radius-specimen {
+  width: 5rem;
+  height: 5rem;
+  border: 2px solid rgb(var(--primary-500));
+  background: rgb(var(--primary-50));
+}
+
+.shadow-specimen {
+  width: 9rem;
+  height: 5.5rem;
+  border-radius: var(--radius-lg);
+  background: rgb(var(--surface));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.specimen-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: rgb(var(--muted-foreground));
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+/* ---------- do / don't ---------- */
+
+.do-dont {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  margin-top: 1.25rem;
+}
+
+.do-dont > div {
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  overflow: hidden;
+}
+
+.do-dont .do-dont-label {
+  display: block;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.do-dont .do > .do-dont-label { background: rgb(var(--success-100)); color: rgb(var(--success-800)); }
+.do-dont .dont > .do-dont-label { background: rgb(var(--error-100)); color: rgb(var(--error-800)); }
+
+.do-dont .do { border-top: 3px solid rgb(var(--success-500)); }
+.do-dont .dont { border-top: 3px solid rgb(var(--error-500)); }
+
+.do-dont pre {
+  margin: 0;
+  padding: 0.875rem 1rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.7;
+}
+
+.do-dont p {
+  margin: 0;
+  padding: 0 1rem 0.875rem;
+  font-size: 0.8125rem;
+  color: rgb(var(--muted-foreground));
+}
+
+/* ---------- prop tables ---------- */
+
+.ds-table-wrap {
+  overflow-x: auto;
+  margin-top: 1rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-lg);
+}
+
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  background: rgb(var(--surface));
+}
+
+.ds-table th,
+.ds-table td {
+  text-align: left;
+  padding: 0.625rem 0.875rem;
+  border-bottom: 1px solid rgb(var(--border));
+  vertical-align: top;
+}
+
+.ds-table th {
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(var(--muted-foreground));
+  background: rgb(var(--muted) / 0.5);
+}
+
+.ds-table tr:last-child td { border-bottom: 0; }
+
+/* ---------- misc ---------- */
+
+.ds-note {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid rgb(var(--primary-500));
+  border-radius: var(--radius);
+  background: rgb(var(--primary-50));
+  color: rgb(var(--primary-800));
+  font-size: 0.8125rem;
+}
+
+.ds-note a {
+  color: inherit;
+  font-weight: 700;
+}
+
+.ds-anchor-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ds-anchor-list a {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-full);
+  background: rgb(var(--surface));
+  color: rgb(var(--muted-foreground));
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ds-anchor-list a:hover {
+  color: rgb(var(--primary-700));
+  border-color: rgb(var(--primary-300));
+}
+
+.theme-icon-dark { display: none; }
+:root[data-theme='dark'] .theme-icon-dark { display: inline; }
+:root[data-theme='dark'] .theme-icon-light { display: none; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .theme-icon-dark { display: inline; }
+  :root:not([data-theme]) .theme-icon-light { display: none; }
+}

--- a/design-system/site.js
+++ b/design-system/site.js
@@ -1,0 +1,183 @@
+/*
+ * Guide behavior. Brand values are never hardcoded here — swatches and
+ * specimens read the live custom properties from the ui package stylesheet,
+ * so the guide re-renders itself whenever the tokens change.
+ */
+
+/* ---------- theme toggle (matches the data-theme contract) ---------- */
+
+const THEME_KEY = 'rsc-ds-theme';
+
+function applyTheme(theme) {
+  if (theme) {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem(THEME_KEY, theme);
+  }
+  renderSwatches();
+}
+
+function currentTheme() {
+  const explicit = document.documentElement.dataset.theme;
+  if (explicit) return explicit;
+  return matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+for (const btn of document.querySelectorAll('[data-theme-toggle]')) {
+  btn.addEventListener('click', () => {
+    applyTheme(currentTheme() === 'dark' ? 'light' : 'dark');
+  });
+}
+
+matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => renderSwatches());
+
+/* ---------- mobile nav ---------- */
+
+const menuBtn = document.querySelector('.app-nav-menu-btn');
+if (menuBtn) {
+  menuBtn.addEventListener('click', () => {
+    document.querySelector('.app-nav-collapse')?.classList.toggle('app-nav-collapse-open');
+  });
+}
+
+/* ---------- token swatches (read live from the stylesheet) ---------- */
+
+const RAMP_STEPS = ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'];
+
+function readToken(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function tripletToHex(triplet) {
+  const parts = triplet.split(/\s+/).map(Number);
+  if (parts.length !== 3 || parts.some(Number.isNaN)) return triplet;
+  return `#${parts.map(n => n.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function swatchButton(varName, chipStyle, title, subtitle) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'swatch';
+  btn.title = `Copy rgb(var(${varName}))`;
+
+  const chip = document.createElement('span');
+  chip.className = 'swatch-chip';
+  chip.style.background = chipStyle;
+
+  const copy = document.createElement('span');
+  copy.className = 'swatch-copy';
+  copy.innerHTML = `<strong>${title}</strong>${subtitle}`;
+
+  btn.append(chip, copy);
+  btn.addEventListener('click', () => {
+    navigator.clipboard?.writeText(`rgb(var(${varName}))`);
+    const original = copy.innerHTML;
+    copy.innerHTML = `<strong>${title}</strong>copied!`;
+    setTimeout(() => { copy.innerHTML = original; }, 900);
+  });
+  return btn;
+}
+
+function renderSwatches() {
+  for (const rampEl of document.querySelectorAll('[data-ramp]')) {
+    const ramp = rampEl.dataset.ramp;
+    rampEl.textContent = '';
+    for (const step of RAMP_STEPS) {
+      const varName = `--${ramp}-${step}`;
+      const value = readToken(varName);
+      if (!value) continue;
+      rampEl.append(swatchButton(varName, `rgb(${value})`, step, tripletToHex(value)));
+    }
+  }
+
+  for (const groundEl of document.querySelectorAll('[data-ground-tokens]')) {
+    groundEl.textContent = '';
+    for (const name of ['background', 'surface', 'foreground', 'muted', 'muted-foreground', 'border', 'ring']) {
+      const varName = `--${name}`;
+      const value = readToken(varName);
+      if (!value) continue;
+      groundEl.append(swatchButton(varName, `rgb(${value})`, `--${name}`, tripletToHex(value)));
+    }
+  }
+}
+
+renderSwatches();
+
+/* ---------- sparklines (window.rscUi from the ui package browser bundle) ---------- */
+
+function drawSparklines() {
+  if (!window.rscUi) return;
+  for (const el of document.querySelectorAll('[data-sparkline]')) {
+    try {
+      window.rscUi.renderSparkline(el, JSON.parse(el.dataset.sparkline));
+    } catch { /* malformed demo data — leave the element empty */ }
+  }
+}
+
+drawSparklines();
+
+/* ---------- interactive demos ---------- */
+
+// Segmented control demos: clicking moves aria-pressed.
+for (const group of document.querySelectorAll('.demo .segmented-control')) {
+  group.addEventListener('click', event => {
+    const btn = event.target.closest('.segmented-control-option');
+    if (!btn || btn.disabled) return;
+    for (const option of group.querySelectorAll('.segmented-control-option')) {
+      option.setAttribute('aria-pressed', String(option === btn));
+    }
+  });
+}
+
+// Modal demo.
+for (const opener of document.querySelectorAll('[data-open-modal]')) {
+  opener.addEventListener('click', () => {
+    document.getElementById(opener.dataset.openModal)?.showModal();
+  });
+}
+
+/* ---------- code tabs + copy ---------- */
+
+for (const block of document.querySelectorAll('.demo-code')) {
+  const panes = [...block.querySelectorAll('pre[data-lang]')];
+  const bar = document.createElement('div');
+  bar.className = 'demo-code-tabs';
+
+  if (panes.length > 1) {
+    const tabs = document.createElement('div');
+    tabs.className = 'segmented-control';
+    tabs.setAttribute('role', 'group');
+    tabs.setAttribute('aria-label', 'Code language');
+    panes.forEach((pane, index) => {
+      const tab = document.createElement('button');
+      tab.type = 'button';
+      tab.className = 'segmented-control-option';
+      tab.textContent = pane.dataset.lang;
+      tab.setAttribute('aria-pressed', String(index === 0));
+      pane.hidden = index !== 0;
+      tab.addEventListener('click', () => {
+        panes.forEach(p => { p.hidden = p !== pane; });
+        tabs.querySelectorAll('.segmented-control-option').forEach(t => {
+          t.setAttribute('aria-pressed', String(t === tab));
+        });
+      });
+      tabs.append(tab);
+    });
+    bar.append(tabs);
+  } else {
+    bar.append(document.createElement('span'));
+  }
+
+  const copy = document.createElement('button');
+  copy.type = 'button';
+  copy.className = 'ds-copy';
+  copy.textContent = 'copy';
+  copy.addEventListener('click', () => {
+    const visible = panes.find(p => !p.hidden) ?? panes[0];
+    navigator.clipboard?.writeText(visible.textContent.trim());
+    copy.textContent = 'copied!';
+    setTimeout(() => { copy.textContent = 'copy'; }, 900);
+  });
+  bar.append(copy);
+
+  block.prepend(bar);
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,16 @@
 import pluginJs from "@eslint/js";
+import globals from "globals";
 
 export default [
+  {
+    // Design-system guide scripts run in the browser
+    files: ['design-system/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'script',
+      globals: globals.browser
+    }
+  },
   {
     files: ['**/*.mjs'],
     languageOptions: {

--- a/scripts/build-design-site.mjs
+++ b/scripts/build-design-site.mjs
@@ -1,0 +1,32 @@
+/*
+ * Assembles the design-system guide (GitHub Pages) into dist-design-site/.
+ *
+ * The guide's pages reference the ui package's OWN stylesheets and browser
+ * bundles (ui/styles/*, ui/dist/browser/*, ui/assets/*) — this script just
+ * copies the authored pages and the live package files together, so the
+ * published guide can never drift from the shipped system.
+ *
+ * Usage: node scripts/build-design-site.mjs
+ * Run `npm run build` in ui/ first (dist/browser must exist).
+ */
+
+import { cp, mkdir, rm, access } from 'fs/promises';
+
+const OUT = 'dist-design-site';
+
+try {
+  await access('ui/dist/browser');
+} catch {
+  console.error('ui/dist/browser missing — run `npm run build` in ui/ first.');
+  process.exit(1);
+}
+
+await rm(OUT, { recursive: true, force: true });
+await mkdir(OUT, { recursive: true });
+
+await cp('design-system', OUT, { recursive: true });
+await cp('ui/styles', `${OUT}/ui/styles`, { recursive: true });
+await cp('ui/assets', `${OUT}/ui/assets`, { recursive: true });
+await cp('ui/dist/browser', `${OUT}/ui/dist`, { recursive: true });
+
+console.log(`Design-system guide assembled in ${OUT}/`);

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -23,6 +23,7 @@ Source lives in `rsc-core/ui`. **Never fork or copy this code into an app — ch
 4. **Respect the responsive contract.** Components ship with 44px touch targets, ≥16px mobile inputs, fluid type, and safe-area handling. Don't override these down.
 5. **Don't change the `rsc:auth` session contract** (`{idToken, refreshToken, expiresAt}` in localStorage under key `rsc:auth`). The vanilla course pages and the platform share sessions through it. Change it only deliberately, on both sides, in this package.
 6. **Dark mode** is system-preference by default with `<html data-theme="dark|light">` override. Never implement a separate theming mechanism.
+7. **Never stack `dark:` variants on token colors.** The token scales AUTO-INVERT in dark mode (`--success-100` flips dark, `--success-900` flips light), so a single token class (`bg-success-100 text-success-800`) is already correct in both themes. Adding a Tailwind `dark:` override on top double-inverts and washes out contrast. If a component looks wrong in dark mode, fix the token usage — don't add `dark:`.
 
 ## Install (React apps)
 
@@ -65,6 +66,12 @@ All components are typed, accept `className`, and forward standard HTML props.
 | `Field` | `label`, `error`, `hint`, `children: (props) => ReactNode` | Render-prop for wiring custom controls. |
 | `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardBody`, `CardFooter` | div props | Compound card. |
 | `Badge` | `variant: 'primary'\|'success'\|'warning'\|'error'\|'neutral'` | Status pill (uppercase mono). |
+| `StatusBadge` | `tone: 'success'\|'warning'\|'error'\|'primary'\|'neutral'`, `icon?` | Sentence-case health/state pill (icon + label, tone-100 bg / tone-800 text). Use for health readouts and threshold flags; use `Badge` for uppercase mono tags. |
+| `TrendPill` | `delta`, `invert?`, `precision?`, `suffix?` | Colored delta chip (`+6.3% ↗`). Color = is the change an improvement; pass `invert` when down is good (bounce, unsubscribes). Zero delta = neutral, no arrow. |
+| `TrendSparkline` | `values: number[]` | Decorative aria-hidden trend line with the last point emphasized. Renders null with <2 points. Vanilla: `renderSparkline(el, values)` (also on `window.rscUi`). |
+| `SegmentedControl` | `options: {value,label,disabled?}[]`, `value`, `onChange`, `aria-label` (required) | Compact multi-option toggle (`aria-pressed` buttons on a muted track). For comparison baselines, view switches, filter tabs. |
+| `StatTile` | `label`, `value`, `delta?`, `invertDelta?`, `status?: {tone,label}`, `meta?`, `icon?`, `sparkline?` | Dashboard metric tile: uppercase label, display-font value, delta `TrendPill`, threshold `StatusBadge`, caption, and footer sparkline. |
+| `PageHero` (+`PageHeroTitle`, `PageHeroSubtitle`, `PageHeroChips`, `PageHeroChip`) | chip: `tone: 'neutral'\|'primary'\|'success'\|'warning'\|'error'`, `icon?` | Gradient hero band that opens a page (surface→primary wash + blurred accent blob, drawn in CSS) with pill meta chips. |
 | `Alert` | `variant: 'error'\|'success'\|'info'` | `role="alert"` for errors. |
 | `Modal` | `open`, `onClose`, `aria-label` | Native `<dialog>`: Esc/backdrop close, focus trap free. Bottom sheet on ≤640px. |
 | `ToastProvider` / `useToast()` | `toast(message, { variant?, duration? })` | Mount provider once at app root. Errors default to 8s, others 5s. |
@@ -284,6 +291,7 @@ Published to the assets bucket on every rsc-core deploy:
 - `ui/<version>/` is immutable (1y cache); `ui/latest/` is a 5-minute pointer
 - `styles/tokens.css` alone = variables only (for a site keeping its own components but adopting the palette)
 - `auth.global.js` exposes the full core as `window.rscAuth` — same `rsc:auth` contract, so it shares sessions with npm-consuming SPAs on the same origin
+- `ui.global.js` exposes drawing helpers as `window.rscUi` (`renderSparkline(el, values)`); everything else in the analytics kit (stat tiles, trend pills, segmented controls, page heroes, status badges) is pure CSS — just use the shipped classes
 
 ## Migration playbooks
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readysetcloud/ui",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "react-markdown": "^9.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readysetcloud/ui",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Shared design tokens, UI components, and Cognito auth for Ready, Set, Cloud apps",
   "license": "MIT",
   "type": "module",

--- a/ui/src/components/PageHero.tsx
+++ b/ui/src/components/PageHero.tsx
@@ -1,0 +1,46 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from './cx';
+
+export type PageHeroChipTone = 'neutral' | 'primary' | 'success' | 'warning' | 'error';
+
+/**
+ * Gradient hero band that opens a page: surface-to-primary wash with a soft
+ * accent blob (drawn in CSS), display-font title, and pill meta chips.
+ */
+export function PageHero({ className, children, ...rest }: HTMLAttributes<HTMLElement>) {
+  return (
+    <header className={cx('page-hero', className)} {...rest}>
+      <div className="page-hero-content">{children}</div>
+    </header>
+  );
+}
+
+export function PageHeroTitle({ className, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h1 className={cx('page-hero-title', className)} {...rest} />;
+}
+
+export function PageHeroSubtitle({ className, ...rest }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cx('page-hero-subtitle', className)} {...rest} />;
+}
+
+export function PageHeroChips({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('page-hero-chips', className)} {...rest} />;
+}
+
+export interface PageHeroChipProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: PageHeroChipTone;
+  /** Optional leading icon; rendered aria-hidden. */
+  icon?: ReactNode;
+}
+
+export function PageHeroChip({ tone = 'neutral', icon, className, children, ...rest }: PageHeroChipProps) {
+  return (
+    <span
+      className={cx('page-hero-chip', tone !== 'neutral' && `page-hero-chip-${tone}`, className)}
+      {...rest}
+    >
+      {icon != null && <span aria-hidden="true">{icon}</span>}
+      {children}
+    </span>
+  );
+}

--- a/ui/src/components/SegmentedControl.tsx
+++ b/ui/src/components/SegmentedControl.tsx
@@ -1,0 +1,46 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from './cx';
+
+export interface SegmentedControlOption<T extends string = string> {
+  value: T;
+  label: ReactNode;
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps<T extends string = string>
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  options: SegmentedControlOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  /** Accessible name for the group, e.g. "Comparison baseline". */
+  'aria-label': string;
+}
+
+/**
+ * Compact multi-option toggle (comparison baselines, view switches, tabs-as-
+ * filter). One option is always pressed; state is exposed via aria-pressed.
+ */
+export function SegmentedControl<T extends string = string>({
+  options,
+  value,
+  onChange,
+  className,
+  ...rest
+}: SegmentedControlProps<T>) {
+  return (
+    <div className={cx('segmented-control', className)} role="group" {...rest}>
+      {options.map(option => (
+        <button
+          key={option.value}
+          type="button"
+          className="segmented-control-option"
+          aria-pressed={value === option.value}
+          disabled={option.disabled}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/StatTile.tsx
+++ b/ui/src/components/StatTile.tsx
@@ -1,0 +1,83 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from './cx';
+import { StatusBadge, type StatusBadgeTone } from './StatusBadge';
+import { TrendPill } from './TrendPill';
+import { TrendSparkline } from './TrendSparkline';
+
+export interface StatTileStatus {
+  tone: Extract<StatusBadgeTone, 'warning' | 'error'> | StatusBadgeTone;
+  label: ReactNode;
+}
+
+export interface StatTileProps extends HTMLAttributes<HTMLDivElement> {
+  /** Uppercase caption above the value, e.g. "Open Rate". */
+  label: ReactNode;
+  /** Headline value, e.g. "48.0%". */
+  value: ReactNode;
+  /** Change vs. the comparison baseline; renders a TrendPill when non-zero. */
+  delta?: number;
+  /** Set when a falling delta is good (bounce rate, unsubscribes). */
+  invertDelta?: boolean;
+  deltaPrecision?: number;
+  deltaSuffix?: string;
+  /** Threshold/health badge shown beside the label. */
+  status?: StatTileStatus;
+  /** Caption line under the value ("1,234 opens · vs. avg"). */
+  meta?: ReactNode;
+  /** Decorative icon bubble in the top-right corner. */
+  icon?: ReactNode;
+  /** Metric history (oldest first) for the footer sparkline. */
+  sparkline?: number[];
+}
+
+/**
+ * Dashboard metric tile: uppercase label, display-font value, and optional
+ * delta pill, status badge, caption, icon, and trend sparkline — the shared
+ * chrome behind analytics dashboards. Fully composable: children render
+ * after the built-in slots for anything bespoke.
+ */
+export function StatTile({
+  label,
+  value,
+  delta,
+  invertDelta,
+  deltaPrecision,
+  deltaSuffix,
+  status,
+  meta,
+  icon,
+  sparkline,
+  className,
+  children,
+  ...rest
+}: StatTileProps) {
+  return (
+    <div className={cx('stat-tile', className)} {...rest}>
+      <div className="stat-tile-header">
+        <div>
+          <div className="stat-tile-label">{label}</div>
+          <div className="stat-tile-row">
+            <span className="stat-tile-value">{value}</span>
+            {delta !== undefined && delta !== 0 && (
+              <TrendPill
+                delta={delta}
+                invert={invertDelta}
+                precision={deltaPrecision}
+                suffix={deltaSuffix}
+              />
+            )}
+            {status && <StatusBadge tone={status.tone}>{status.label}</StatusBadge>}
+          </div>
+        </div>
+        {icon != null && <span className="stat-tile-icon" aria-hidden="true">{icon}</span>}
+      </div>
+      {meta != null && <div className="stat-tile-meta">{meta}</div>}
+      {children}
+      {sparkline && sparkline.length >= 2 && (
+        <div className="stat-tile-footer">
+          <TrendSparkline values={sparkline} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/StatusBadge.tsx
+++ b/ui/src/components/StatusBadge.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from './cx';
+
+export type StatusBadgeTone = 'success' | 'warning' | 'error' | 'primary' | 'neutral';
+
+export interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: StatusBadgeTone;
+  /** Optional leading icon; rendered aria-hidden — the label carries meaning. */
+  icon?: ReactNode;
+}
+
+/**
+ * Sentence-case health/state pill (e.g. "✓ Stable", "High"). The tone ramps
+ * auto-invert in dark mode, so one tone renders correctly in both themes.
+ * For the uppercase mono tag, use Badge instead.
+ */
+export function StatusBadge({ tone = 'neutral', icon, className, children, ...rest }: StatusBadgeProps) {
+  return (
+    <span className={cx('status-badge', `status-badge-${tone}`, className)} role="status" {...rest}>
+      {icon != null && <span aria-hidden="true">{icon}</span>}
+      {children}
+    </span>
+  );
+}

--- a/ui/src/components/TrendPill.tsx
+++ b/ui/src/components/TrendPill.tsx
@@ -1,0 +1,64 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+
+export interface TrendPillProps extends HTMLAttributes<HTMLSpanElement> {
+  /** The change being described, e.g. +6.3 for a 6.3-point improvement. */
+  delta: number;
+  /** Set when a falling metric is good (bounce rate, unsubscribes, errors). */
+  invert?: boolean;
+  /** Decimal places for the default label. */
+  precision?: number;
+  /** Suffix appended to the default label. */
+  suffix?: string;
+}
+
+const ARROW_UP = 'M3 10.5 8 5.5 13 10.5';
+const ARROW_DOWN = 'M3 5.5 8 10.5 13 5.5';
+
+/**
+ * Colored delta chip rendered next to a metric value ("+6.3% ↗"). Color
+ * encodes whether the change is an improvement — pass `invert` for metrics
+ * where down is good. A zero delta renders the neutral pill with no arrow.
+ * Children override the default formatted label.
+ */
+export function TrendPill({
+  delta,
+  invert = false,
+  precision = 1,
+  suffix = '%',
+  className,
+  children,
+  ...rest
+}: TrendPillProps) {
+  const direction = delta > 0 ? 'up' : delta < 0 ? 'down' : 'neutral';
+  const sentiment =
+    direction === 'neutral' ? 'neutral' : (delta > 0) !== invert ? 'positive' : 'negative';
+  const label = children ?? `${delta > 0 ? '+' : ''}${delta.toFixed(precision)}${suffix}`;
+
+  return (
+    <span
+      className={cx('trend-pill', `trend-pill-${sentiment}`, className)}
+      role="status"
+      aria-label={
+        direction === 'neutral'
+          ? 'No change'
+          : `Trend ${sentiment === 'positive' ? 'improving' : 'declining'}: ${label}`
+      }
+      {...rest}
+    >
+      {direction !== 'neutral' && (
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d={direction === 'up' ? ARROW_UP : ARROW_DOWN}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+      {label}
+    </span>
+  );
+}

--- a/ui/src/components/TrendSparkline.tsx
+++ b/ui/src/components/TrendSparkline.tsx
@@ -1,0 +1,50 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from './cx';
+import {
+  SPARKLINE_VIEWBOX_HEIGHT,
+  SPARKLINE_VIEWBOX_WIDTH,
+  sparklineGeometry
+} from './sparkline';
+
+export interface TrendSparklineProps extends HTMLAttributes<HTMLDivElement> {
+  /** Metric history, oldest first. Needs at least two points to render. */
+  values: number[];
+}
+
+/**
+ * Decorative trend line for a metric across recent periods, with the latest
+ * point emphasized. The values are surfaced as text elsewhere (e.g. in the
+ * StatTile), so the whole drawing is aria-hidden.
+ */
+export function TrendSparkline({ values, className, ...rest }: TrendSparklineProps) {
+  const geometry = sparklineGeometry(values);
+
+  if (!geometry) return null;
+
+  return (
+    <div className={cx('sparkline', className)} aria-hidden="true" {...rest}>
+      <svg
+        viewBox={`0 0 ${SPARKLINE_VIEWBOX_WIDTH} ${SPARKLINE_VIEWBOX_HEIGHT}`}
+        preserveAspectRatio="none"
+      >
+        <path d={geometry.area} fill="currentColor" opacity={0.12} />
+        <polyline
+          points={geometry.line}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <span
+        className="sparkline-dot"
+        style={{
+          left: `${geometry.last.x}%`,
+          top: `${(geometry.last.y / SPARKLINE_VIEWBOX_HEIGHT) * 100}%`
+        }}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/analytics.test.tsx
+++ b/ui/src/components/analytics.test.tsx
@@ -1,0 +1,208 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PageHero, PageHeroChip, PageHeroChips, PageHeroTitle } from './PageHero';
+import { SegmentedControl } from './SegmentedControl';
+import { StatTile } from './StatTile';
+import { StatusBadge } from './StatusBadge';
+import { TrendPill } from './TrendPill';
+import { TrendSparkline } from './TrendSparkline';
+import { renderSparkline, sparklineGeometry } from './sparkline';
+
+afterEach(cleanup);
+
+describe('StatusBadge', () => {
+  it('renders the tone class and label', () => {
+    render(<StatusBadge tone="success">Stable</StatusBadge>);
+
+    const badge = screen.getByRole('status');
+    expect(badge.className).toContain('status-badge-success');
+    expect(badge.textContent).toContain('Stable');
+  });
+
+  it('hides the icon from assistive tech', () => {
+    render(<StatusBadge tone="warning" icon="⚠">High</StatusBadge>);
+
+    const icon = screen.getByText('⚠');
+    expect(icon.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('TrendPill', () => {
+  it('renders an improvement as positive with a plus sign', () => {
+    render(<TrendPill delta={6.3} />);
+
+    const pill = screen.getByRole('status');
+    expect(pill.className).toContain('trend-pill-positive');
+    expect(pill.textContent).toContain('+6.3%');
+  });
+
+  it('treats a falling inverted metric as an improvement', () => {
+    render(<TrendPill delta={-0.4} invert />);
+
+    const pill = screen.getByRole('status');
+    expect(pill.className).toContain('trend-pill-positive');
+    expect(pill.textContent).toContain('-0.4%');
+  });
+
+  it('treats a rising inverted metric as a decline', () => {
+    render(<TrendPill delta={2.1} invert />);
+
+    expect(screen.getByRole('status').className).toContain('trend-pill-negative');
+  });
+
+  it('renders a zero delta as neutral with no arrow', () => {
+    const { container } = render(<TrendPill delta={0} />);
+
+    expect(screen.getByRole('status').className).toContain('trend-pill-neutral');
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});
+
+describe('SegmentedControl', () => {
+  const options = [
+    { value: 'average', label: 'Average' },
+    { value: 'last', label: 'Last issue' },
+    { value: 'best', label: 'Best issue' }
+  ];
+
+  it('marks the active option pressed and fires onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        aria-label="Comparison baseline"
+        options={options}
+        value="average"
+        onChange={onChange}
+      />
+    );
+
+    const group = screen.getByRole('group', { name: 'Comparison baseline' });
+    expect(group.className).toContain('segmented-control');
+
+    const active = screen.getByRole('button', { name: 'Average' });
+    expect(active.getAttribute('aria-pressed')).toBe('true');
+
+    const last = screen.getByRole('button', { name: 'Last issue' });
+    expect(last.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(last);
+    expect(onChange).toHaveBeenCalledWith('last');
+  });
+
+  it('respects disabled options', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        aria-label="View"
+        options={[{ value: 'a', label: 'A' }, { value: 'b', label: 'B', disabled: true }]}
+        value="a"
+        onChange={onChange}
+      />
+    );
+
+    const disabled = screen.getByRole('button', { name: 'B' });
+    fireEvent.click(disabled);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('TrendSparkline', () => {
+  it('renders nothing with fewer than two points', () => {
+    const { container } = render(<TrendSparkline values={[42]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders an aria-hidden drawing with an emphasized last point', () => {
+    const { container } = render(<TrendSparkline values={[1, 3, 2, 5]} />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain('sparkline');
+    expect(wrapper.getAttribute('aria-hidden')).toBe('true');
+    expect(wrapper.querySelector('polyline')).not.toBeNull();
+
+    const dot = wrapper.querySelector('.sparkline-dot') as HTMLElement;
+    expect(dot.style.left).toBe('100%');
+  });
+});
+
+describe('sparkline core', () => {
+  it('returns null for fewer than two points', () => {
+    expect(sparklineGeometry([])).toBeNull();
+    expect(sparklineGeometry([1])).toBeNull();
+  });
+
+  it('maps values onto the viewBox with the last point at x=100', () => {
+    const geometry = sparklineGeometry([0, 10]);
+    expect(geometry).not.toBeNull();
+    expect(geometry!.last.x).toBe(100);
+    expect(geometry!.last.y).toBe(3); // max value sits at the top padding
+  });
+
+  it('centers a flat series vertically', () => {
+    const geometry = sparklineGeometry([5, 5, 5]);
+    expect(geometry!.last.y).toBe(14);
+  });
+
+  it('renders the same drawing without React', () => {
+    const host = document.createElement('div');
+    renderSparkline(host, [1, 2, 3]);
+
+    expect(host.className).toContain('sparkline');
+    expect(host.querySelector('polyline')).not.toBeNull();
+    expect(host.querySelector('.sparkline-dot')).not.toBeNull();
+
+    renderSparkline(host, [1]);
+    expect(host.querySelector('svg')).toBeNull();
+  });
+});
+
+describe('StatTile', () => {
+  it('renders label, value, delta pill, status badge, meta, and sparkline', () => {
+    const { container } = render(
+      <StatTile
+        label="Bounce Rate"
+        value="1.3%"
+        delta={-0.4}
+        invertDelta
+        status={{ tone: 'warning', label: 'High' }}
+        meta="67 bounces · vs. avg"
+        sparkline={[2, 1.8, 1.5, 1.3]}
+      />
+    );
+
+    expect(screen.getByText('Bounce Rate')).toBeDefined();
+    expect(screen.getByText('1.3%')).toBeDefined();
+    expect(screen.getByText('High')).toBeDefined();
+    expect(screen.getByText('67 bounces · vs. avg')).toBeDefined();
+    expect(container.querySelector('.trend-pill-positive')).not.toBeNull();
+    expect(container.querySelector('.sparkline')).not.toBeNull();
+  });
+
+  it('omits the pill for a zero delta and the sparkline for short series', () => {
+    const { container } = render(<StatTile label="Opens" value="1,234" delta={0} sparkline={[1]} />);
+
+    expect(container.querySelector('.trend-pill')).toBeNull();
+    expect(container.querySelector('.sparkline')).toBeNull();
+  });
+});
+
+describe('PageHero', () => {
+  it('renders a header band with title and toned chips', () => {
+    render(
+      <PageHero>
+        <PageHeroTitle>Serverless Picks of the Week</PageHeroTitle>
+        <PageHeroChips>
+          <PageHeroChip>Issue #204</PageHeroChip>
+          <PageHeroChip tone="success">Sent Jul 21</PageHeroChip>
+        </PageHeroChips>
+      </PageHero>
+    );
+
+    const title = screen.getByRole('heading', { level: 1, name: 'Serverless Picks of the Week' });
+    expect(title.className).toContain('page-hero-title');
+
+    const sent = screen.getByText('Sent Jul 21');
+    expect(sent.className).toContain('page-hero-chip-success');
+    expect(screen.getByText('Issue #204').className).not.toContain('page-hero-chip-neutral');
+  });
+});

--- a/ui/src/components/sparkline.ts
+++ b/ui/src/components/sparkline.ts
@@ -1,0 +1,92 @@
+/*
+ * Framework-agnostic sparkline core. The React <TrendSparkline> and the
+ * vanilla renderSparkline() both draw from this geometry so every surface
+ * renders the identical trend line.
+ */
+
+export const SPARKLINE_VIEWBOX_WIDTH = 100;
+export const SPARKLINE_VIEWBOX_HEIGHT = 28;
+
+export interface SparklinePoint {
+  x: number;
+  y: number;
+}
+
+export interface SparklineGeometry {
+  /** Polyline points attribute for the trend line. */
+  line: string;
+  /** Path data for the soft area fill under the line. */
+  area: string;
+  /** The final (most recent) point, emphasized as a dot. */
+  last: SparklinePoint;
+}
+
+/**
+ * Maps a metric history (oldest first) onto the 100x28 sparkline viewBox.
+ * Returns null when there are fewer than two points — nothing to draw.
+ */
+export function sparklineGeometry(values: number[]): SparklineGeometry | null {
+  if (values.length < 2) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  const top = 3;
+  const bottom = 25;
+
+  const points = values.map((value, index) => {
+    const x = (index / (values.length - 1)) * SPARKLINE_VIEWBOX_WIDTH;
+    const y = range === 0 ? (top + bottom) / 2 : bottom - ((value - min) / range) * (bottom - top);
+    return { x, y };
+  });
+
+  const line = points.map(p => `${p.x},${p.y}`).join(' ');
+  const area = `M0,${SPARKLINE_VIEWBOX_HEIGHT} L${points.map(p => `${p.x},${p.y}`).join(' L')} L${SPARKLINE_VIEWBOX_WIDTH},${SPARKLINE_VIEWBOX_HEIGHT} Z`;
+  const last = points[points.length - 1]!;
+
+  return { line, area, last };
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Vanilla renderer for script-tag consumers: fills `el` with the sparkline
+ * markup (same classes and drawing as the React component). Clears the
+ * element when there are fewer than two values.
+ */
+export function renderSparkline(el: HTMLElement, values: number[]): void {
+  const geometry = sparklineGeometry(values);
+  el.textContent = '';
+
+  if (!geometry) return;
+
+  el.classList.add('sparkline');
+  el.setAttribute('aria-hidden', 'true');
+
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${SPARKLINE_VIEWBOX_WIDTH} ${SPARKLINE_VIEWBOX_HEIGHT}`);
+  svg.setAttribute('preserveAspectRatio', 'none');
+
+  const area = document.createElementNS(SVG_NS, 'path');
+  area.setAttribute('d', geometry.area);
+  area.setAttribute('fill', 'currentColor');
+  area.setAttribute('opacity', '0.12');
+
+  const line = document.createElementNS(SVG_NS, 'polyline');
+  line.setAttribute('points', geometry.line);
+  line.setAttribute('fill', 'none');
+  line.setAttribute('stroke', 'currentColor');
+  line.setAttribute('stroke-width', '1.5');
+  line.setAttribute('stroke-linejoin', 'round');
+  line.setAttribute('stroke-linecap', 'round');
+  line.setAttribute('vector-effect', 'non-scaling-stroke');
+
+  svg.append(area, line);
+
+  const dot = document.createElement('span');
+  dot.className = 'sparkline-dot';
+  dot.style.left = `${geometry.last.x}%`;
+  dot.style.top = `${(geometry.last.y / SPARKLINE_VIEWBOX_HEIGHT) * 100}%`;
+
+  el.append(svg, dot);
+}

--- a/ui/src/components/ui-browser.ts
+++ b/ui/src/components/ui-browser.ts
@@ -1,0 +1,15 @@
+/*
+ * Framework-agnostic UI helpers for plain <script> consumers (window.rscUi).
+ * Everything CSS-only (stat tiles, trend pills, segmented controls, page
+ * heroes, status badges) needs no JS — just the shipped classes. This bundle
+ * carries the pieces that require drawing.
+ */
+
+export {
+  renderSparkline,
+  sparklineGeometry,
+  SPARKLINE_VIEWBOX_HEIGHT,
+  SPARKLINE_VIEWBOX_WIDTH,
+  type SparklineGeometry,
+  type SparklinePoint
+} from './sparkline';

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -71,6 +71,30 @@ export {
   type RscServiceAccess,
   type RscServiceRegistry
 } from './services/registry';
+export { StatusBadge, type StatusBadgeProps, type StatusBadgeTone } from './components/StatusBadge';
+export { TrendPill, type TrendPillProps } from './components/TrendPill';
+export { TrendSparkline, type TrendSparklineProps } from './components/TrendSparkline';
+export {
+  sparklineGeometry,
+  renderSparkline,
+  type SparklineGeometry,
+  type SparklinePoint
+} from './components/sparkline';
+export {
+  SegmentedControl,
+  type SegmentedControlOption,
+  type SegmentedControlProps
+} from './components/SegmentedControl';
+export { StatTile, type StatTileProps, type StatTileStatus } from './components/StatTile';
+export {
+  PageHero,
+  PageHeroChip,
+  PageHeroChips,
+  PageHeroSubtitle,
+  PageHeroTitle,
+  type PageHeroChipProps,
+  type PageHeroChipTone
+} from './components/PageHero';
 export { BadgeChest, type BadgeChestProps } from './components/BadgeChest';
 export { createBadgeClient, type BadgeClient, type BadgeClientOptions } from './badges/client';
 export type {

--- a/ui/styles/components.css
+++ b/ui/styles/components.css
@@ -1139,6 +1139,357 @@
   text-align: center;
 }
 
+/* ---------- status badge ----------
+   Sentence-case icon + label pill for health/state readouts (bg 100 / text 800
+   / border 200 of a tone). The tone ramps auto-invert in dark mode, so these
+   single declarations render correctly in both themes. Distinct from .badge,
+   which is the uppercase mono tag. */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.625rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-full);
+  background: rgb(var(--muted));
+  color: rgb(var(--muted-foreground));
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.status-badge svg {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex: 0 0 auto;
+}
+
+.status-badge-success {
+  background: rgb(var(--success-100));
+  color: rgb(var(--success-800));
+  border-color: rgb(var(--success-200));
+}
+
+.status-badge-warning {
+  background: rgb(var(--warning-100));
+  color: rgb(var(--warning-800));
+  border-color: rgb(var(--warning-200));
+}
+
+.status-badge-error {
+  background: rgb(var(--error-100));
+  color: rgb(var(--error-800));
+  border-color: rgb(var(--error-200));
+}
+
+.status-badge-primary {
+  background: rgb(var(--primary-100));
+  color: rgb(var(--primary-800));
+  border-color: rgb(var(--primary-200));
+}
+
+.status-badge-neutral {
+  background: rgb(var(--muted));
+  color: rgb(var(--muted-foreground));
+  border-color: rgb(var(--border));
+}
+
+/* ---------- trend pill ----------
+   Colored delta chip ("+6.3% ↗") next to a metric value. Positive = the
+   change is an improvement (which is NOT always "up" — pass the inverted
+   class for metrics where down is good, e.g. bounce rate). */
+
+.trend-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-full);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.trend-pill svg {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex: 0 0 auto;
+}
+
+.trend-pill-positive { background: rgb(var(--success-100)); color: rgb(var(--success-700)); }
+.trend-pill-negative { background: rgb(var(--error-100)); color: rgb(var(--error-700)); }
+.trend-pill-neutral { background: rgb(var(--muted)); color: rgb(var(--muted-foreground)); }
+
+/* ---------- segmented control ----------
+   Compact multi-option toggle: bordered muted track with aria-pressed
+   buttons; the active option pops onto the surface. */
+
+.segmented-control {
+  display: inline-flex;
+  padding: 0.125rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-lg);
+  background: rgb(var(--muted) / 0.3);
+}
+
+.segmented-control-option {
+  min-height: 1.75rem;
+  padding: 0.25rem 0.625rem;
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: rgb(var(--muted-foreground));
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.segmented-control-option:hover {
+  color: rgb(var(--foreground));
+}
+
+.segmented-control-option[aria-pressed='true'] {
+  background: rgb(var(--background));
+  color: rgb(var(--foreground));
+  box-shadow: 0 1px 2px rgb(14 34 51 / 0.1);
+}
+
+.segmented-control-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.segmented-control-option:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--surface)), 0 0 0 4px rgb(var(--ring));
+}
+
+/* ---------- stat tile ----------
+   Dashboard metric tile: uppercase label, display-font value, optional
+   trend pill / status badge / caption / sparkline. Lifts on hover. */
+
+.stat-tile {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-soft);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.stat-tile:hover {
+  border-color: rgb(var(--primary-200));
+  box-shadow: var(--shadow-medium);
+  transform: translateY(-2px);
+}
+
+.stat-tile-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.stat-tile-label {
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgb(var(--muted-foreground));
+}
+
+.stat-tile-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-full);
+  background: rgb(var(--primary-50));
+  color: rgb(var(--primary-600));
+}
+
+.stat-tile-icon svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.stat-tile-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+}
+
+.stat-tile-value {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1;
+  color: rgb(var(--foreground));
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-tile-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.stat-tile-footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+}
+
+/* ---------- sparkline ----------
+   Container for the decorative metric trend line (SVG line + soft area +
+   emphasized last point). The drawing inherits currentColor. */
+
+.sparkline {
+  position: relative;
+  height: 2rem;
+  color: rgb(var(--primary-500));
+}
+
+.sparkline svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.sparkline-dot {
+  position: absolute;
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: var(--radius-full);
+  background: rgb(var(--primary-600));
+  transform: translate(-50%, -50%);
+}
+
+/* ---------- page hero ----------
+   Gradient hero band that opens a page: surface-to-primary wash, soft accent
+   blob, display-font title, and pill meta chips. */
+
+.page-hero {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-xl);
+  background: linear-gradient(
+    135deg,
+    rgb(var(--surface)),
+    rgb(var(--surface)) 55%,
+    rgb(var(--primary-50) / 0.7)
+  );
+  box-shadow: var(--shadow-soft);
+}
+
+.page-hero::before {
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  top: -6rem;
+  right: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: var(--radius-full);
+  background: rgb(var(--primary-500) / 0.1);
+  filter: blur(64px);
+}
+
+.page-hero-content {
+  position: relative;
+  padding: 1.5rem;
+}
+
+.page-hero-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.25rem, 3vw, 1.875rem);
+  font-weight: 700;
+  color: rgb(var(--foreground));
+  overflow-wrap: break-word;
+}
+
+.page-hero-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: rgb(var(--muted-foreground));
+}
+
+.page-hero-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.page-hero-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid rgb(var(--border));
+  border-radius: var(--radius-full);
+  background: rgb(var(--surface) / 0.8);
+  color: rgb(var(--muted-foreground));
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.page-hero-chip svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+}
+
+.page-hero-chip-primary {
+  border-color: rgb(var(--primary-200));
+  background: rgb(var(--primary-50));
+  color: rgb(var(--primary-700));
+}
+
+.page-hero-chip-success {
+  border-color: rgb(var(--success-200));
+  background: rgb(var(--success-50));
+  color: rgb(var(--success-700));
+}
+
+.page-hero-chip-warning {
+  border-color: rgb(var(--warning-200));
+  background: rgb(var(--warning-50));
+  color: rgb(var(--warning-700));
+}
+
+.page-hero-chip-error {
+  border-color: rgb(var(--error-200));
+  background: rgb(var(--error-50));
+  color: rgb(var(--error-700));
+}
+
 /* ---------- badge chest (gamification) ---------- */
 
 .badge-chest {

--- a/ui/tsup.config.ts
+++ b/ui/tsup.config.ts
@@ -38,5 +38,17 @@ export default defineConfig([
     sourcemap: true,
     target: 'es2020',
     platform: 'browser'
+  },
+  // framework-agnostic UI helpers for plain <script> consumers (window.rscUi) —
+  // the drawing pieces (sparklines) that plain CSS classes can't cover
+  {
+    entry: { ui: 'src/components/ui-browser.ts' },
+    outDir: 'dist/browser',
+    format: ['esm', 'iife'],
+    globalName: 'rscUi',
+    minify: true,
+    sourcemap: true,
+    target: 'es2020',
+    platform: 'browser'
   }
 ]);


### PR DESCRIPTION
Adopts the design-system suggestions from readysetcloud/newsletter-service#364
into @readysetcloud/ui (v0.6.0), on both surfaces — typed React components and
the framework-agnostic CSS classes they render:

- TrendSparkline (+ shared sparkline geometry core and a vanilla
  renderSparkline, exposed to script-tag consumers as window.rscUi via a new
  ui.global.js browser bundle)
- TrendPill — colored delta chip; color encodes improvement with an invert
  flag for down-is-good metrics
- SegmentedControl — aria-pressed multi-option toggle
- StatTile — dashboard metric tile chrome (label/value/delta/status/meta/
  sparkline slots)
- PageHero (+Title/Subtitle/Chips/Chip) — gradient hero band with pill chips
- StatusBadge — sentence-case tone pill distinct from the uppercase Badge

Documents the token auto-inversion rule from the PR as hard rule #7 in
ui/AGENTS.md: never stack dark: variants on token colors.

Formalizes the system as a GitHub Pages guide (design-system/): overview,
foundations, components, and patterns pages that consume the ui package's own
stylesheets and browser bundles — swatches and specimens read the live custom
properties at render time, so the guide cannot drift from the package. A new
workflow builds ui/ and deploys the assembled site on pushes to main touching
either the guide or the package.

94 ui tests pass; typecheck, build, and lint clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VxHihuYod3VUyGu1nQ8qvG