### PR TITLE
Formalize the design system: promote newsletter PR #364 components and publish a GitHub Pages guide

### DIFF
--- a/design-system/patterns.html
+++ b/design-system/patterns.html
@@ -179,12 +179,12 @@ import { AuthProvider, useAuth } from '@readysetcloud/ui/auth';</code></pre>
       <div class="demo">
         <div class="demo-header">
           <h3>Vanilla JS</h3>
-          <p>Three script-tag globals cover what CSS can't: auth, the shared navbar, and drawing helpers. Everything else — stat tiles, pills, segmented controls, heroes — is just the shipped classes.</p>
+          <p>Three script-tag globals cover what CSS can't: auth, the shared navbar, and drawing helpers. Everything else — stat tiles, pills, segmented controls, heroes — is just the shipped classes. Point the tags at the hosted assets bucket (the same S3/CDN host as the stylesheet above), never a local copy — that's how every surface stays on one version.</p>
         </div>
         <div class="demo-code">
-<pre data-lang="html"><code>&lt;script src=".../ui/latest/auth.global.js"&gt;&lt;/script&gt; &lt;!-- window.rscAuth --&gt;
-&lt;script src=".../ui/latest/nav.global.js"&gt;&lt;/script&gt;  &lt;!-- window.rscNav --&gt;
-&lt;script src=".../ui/latest/ui.global.js"&gt;&lt;/script&gt;   &lt;!-- window.rscUi --&gt;
+<pre data-lang="html"><code>&lt;script src="https://&lt;assets-host&gt;/ui/latest/auth.global.js"&gt;&lt;/script&gt; &lt;!-- window.rscAuth --&gt;
+&lt;script src="https://&lt;assets-host&gt;/ui/latest/nav.global.js"&gt;&lt;/script&gt;  &lt;!-- window.rscNav --&gt;
+&lt;script src="https://&lt;assets-host&gt;/ui/latest/ui.global.js"&gt;&lt;/script&gt;   &lt;!-- window.rscUi --&gt;
 &lt;script&gt;
   rscAuth.configureAuth({ region: 'us-east-1', clientId: '…' });
   rscNav.mountAppNav('#nav', { appName: 'Bootcamp' /* … */ });

--- a/template.yaml
+++ b/template.yaml
@@ -1154,6 +1154,22 @@ Resources:
       TTL: 300
       Type: CNAME
 
+  # design.${RootDomainName} → the GitHub Pages design-system guide (built and
+  # deployed by .github/workflows/design-system-pages.yaml). Points at the org
+  # Pages apex; GitHub disambiguates by the custom domain set once in the
+  # repo's Pages settings (Settings → Pages → Custom domain =
+  # design.${RootDomainName}), which also provisions the HTTPS certificate.
+  DesignSiteDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: DeployCustomDomainSupport
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub design.${RootDomainName}
+      ResourceRecords:
+        - readysetcloud.github.io
+      TTL: 300
+      Type: CNAME
+
   # The api.${RootDomainName} custom domain already exists in API Gateway
   # (owned by another stack, along with its ACM cert and Route53 record), so we
   # do not create the domain, certificate, or DNS here. Instead we attach the


### PR DESCRIPTION
Adopts the design-system suggestions from [newsletter-service#364](https://github.com/readysetcloud/newsletter-service/pull/364) into `@readysetcloud/ui`, then formalizes the whole system as a GitHub Pages guide that stays in sync with the package by construction.

## Components promoted into `@readysetcloud/ui` (v0.5.3 → 0.6.0)

Every piece PR #364 flagged as a promotion candidate now ships on **both** surfaces — a typed React component **and** the framework-agnostic CSS class it renders (so Hugo/vanilla consumers get pixel-identical UI):

| Component | Notes |
| --- | --- |
| `TrendSparkline` | Lifted from the PR; geometry extracted into a shared, dependency-free core. Vanilla consumers get `renderSparkline(el, values)` via a new `ui.global.js` browser bundle (`window.rscUi`). |
| `TrendPill` | Consolidates the delta-chip pattern duplicated in `KeyMetricsSummary` and `MetricsCard`. Color encodes *improvement*, with an `invert` flag for down-is-good metrics (bounce, unsubscribes). |
| `SegmentedControl` | The `aria-pressed` toggle that appeared in three places (comparison baseline, insights tabs, preview/heatmap switch). |
| `StatTile` | The dashboard tile chrome — label / value / delta / status / meta / sparkline slots. |
| `PageHero` (+ `PageHeroTitle`/`Subtitle`/`Chips`/`Chip`) | The gradient hero band with the blurred accent blob (drawn in CSS — no extra markup). |
| `StatusBadge` | Sentence-case tone pill, kept distinct from the uppercase mono `Badge`. |

Both the suggested React components **and** the agnostic offerings are covered, per the PR's "reflected in both" ask.

## Token auto-inversion documented

Adds the trap PR #364 called out as **hard rule #7** in `ui/AGENTS.md`: the token ramps auto-invert in dark mode, so a single token class is correct in both themes — never stack Tailwind `dark:` variants on token colors (it double-inverts and washes out contrast). The Patterns page below demos this live with do/don't examples.

## Design-system guide (GitHub Pages)

New `design-system/` site — Overview, Foundations, Components, Patterns — that **cannot drift from the package**: the pages link the ui package's own `styles/index.css` and `ui.global.js`, and the color swatches / type specimens read the live CSS custom properties at render time. `scripts/build-design-site.mjs` assembles the guide by copying the package's shipped files alongside the authored pages.

`.github/workflows/design-system-pages.yaml` builds `ui/` and deploys the site on every push to `main` that touches the guide or the package, so docs and package ship together.

## Hosting & custom domain

- The existing `scripts/publish-ui-assets.mjs` already globs `ui/dist/browser/`, so the new `ui.global.js` publishes to the S3 assets bucket (`ui/<version>/` + `ui/latest/`) with no change to that script.
- `template.yaml` gains a `DesignSiteDnsRecord` — a Route53 CNAME `design.${RootDomainName}` → `readysetcloud.github.io`, matching the existing `authenticate.` record and gated on `DeployCustomDomainSupport`.

### Manual steps to go live (after merge + prod deploy)
1. **Settings → Pages → Source → GitHub Actions** (if not already). Pages is already enabled on the repo; confirm the source is Actions, not a branch.
2. **Settings → Pages → Custom domain** → `design.readysetcloud.io`, then tick **Enforce HTTPS** once the cert provisions. This can't be IaC — it lives in the repo's Pages config.

## Verification

- **94 ui tests pass** (new suite covers all six components + the sparkline core), `tsc --noEmit`, build, and lint all clean.
- Guide rendered and screenshotted in headless Chromium across all four pages in **both light and dark themes** — no console errors, token ramps invert correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxHihuYod3VUyGu1nQ8qvG)_