### PR TITLE
Publish ui/AGENTS.md as llms.txt on the design system site

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -16,6 +16,15 @@ regenerate by hand.
 `site.css` / `site.js` style and wire the guide chrome only — never put brand
 values in them.
 
+## LLM version (`/llms.txt`)
+
+The build also publishes `ui/AGENTS.md` verbatim at `/llms.txt` and
+`/AGENTS.md` (plus a preface pointing at `ui/styles/tokens.css` and the
+gallery pages), so AI agents can be pointed at
+`https://design.readysetcloud.io/llms.txt` instead of the repo. There is no
+separate doc to maintain — keep `ui/AGENTS.md` current and the published copy
+follows on the next deploy.
+
 ## Local preview
 
 ```bash

--- a/design-system/components.html
+++ b/design-system/components.html
@@ -6,6 +6,7 @@
   <title>Components · Ready, Set, Cloud Design System</title>
   <meta name="description" content="Live, theme-aware demos of every @readysetcloud/ui component with side-by-side React and plain-HTML usage.">
   <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <link rel="alternate" type="text/markdown" href="llms.txt" title="LLM-readable design system guide">
   <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
   <link rel="stylesheet" href="ui/styles/fonts.css">
   <link rel="stylesheet" href="ui/styles/index.css">
@@ -624,6 +625,7 @@ toast('Subscriber imported.', { variant: 'success' });</code></pre>
   <footer class="ds-footer">
     <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
     <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+    <span>Building with an AI agent? Point it at <a href="llms.txt"><code>llms.txt</code></a> — the full component API and rules in one markdown file.</span>
   </footer>
 
   <script src="ui/dist/ui.global.js"></script>

--- a/design-system/foundations.html
+++ b/design-system/foundations.html
@@ -6,6 +6,7 @@
   <title>Foundations · Ready, Set, Cloud Design System</title>
   <meta name="description" content="Color, typography, shape, and elevation — the token layer of the Ready, Set, Cloud design system, rendered live from the shipped stylesheet.">
   <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <link rel="alternate" type="text/markdown" href="llms.txt" title="LLM-readable design system guide">
   <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
   <link rel="stylesheet" href="ui/styles/fonts.css">
   <link rel="stylesheet" href="ui/styles/index.css">
@@ -182,6 +183,7 @@
   <footer class="ds-footer">
     <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
     <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+    <span>Building with an AI agent? Point it at <a href="llms.txt"><code>llms.txt</code></a> — the full component API and rules in one markdown file.</span>
   </footer>
 
   <script src="ui/dist/ui.global.js"></script>

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -6,6 +6,7 @@
   <title>Ready, Set, Cloud Design System</title>
   <meta name="description" content="The shared design system behind every Ready, Set, Cloud surface — tokens, components, and patterns, rendered from the @readysetcloud/ui package itself.">
   <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <link rel="alternate" type="text/markdown" href="llms.txt" title="LLM-readable design system guide">
   <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
   <link rel="stylesheet" href="ui/styles/fonts.css">
   <link rel="stylesheet" href="ui/styles/index.css">
@@ -183,6 +184,7 @@ module.exports = {
   <footer class="ds-footer">
     <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
     <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+    <span>Building with an AI agent? Point it at <a href="llms.txt"><code>llms.txt</code></a> — the full component API and rules in one markdown file.</span>
   </footer>
 
   <script src="ui/dist/ui.global.js"></script>

--- a/design-system/patterns.html
+++ b/design-system/patterns.html
@@ -6,6 +6,7 @@
   <title>Patterns · Ready, Set, Cloud Design System</title>
   <meta name="description" content="Dark mode and the token auto-inversion rule, the responsive contract, and how each Ready, Set, Cloud surface consumes the design system.">
   <link rel="icon" type="image/svg+xml" href="ui/assets/cloud-logo.svg">
+  <link rel="alternate" type="text/markdown" href="llms.txt" title="LLM-readable design system guide">
   <script>const t = localStorage.getItem('rsc-ds-theme'); if (t) document.documentElement.dataset.theme = t;</script>
   <link rel="stylesheet" href="ui/styles/fonts.css">
   <link rel="stylesheet" href="ui/styles/index.css">
@@ -225,6 +226,7 @@ import { AuthProvider, useAuth } from '@readysetcloud/ui/auth';</code></pre>
   <footer class="ds-footer">
     <span>Ready, Set, Cloud Design System — generated from <a href="https://github.com/readysetcloud/rsc-core">rsc-core</a><code>/ui</code>.</span>
     <span>Change the package, not the guide: this site re-renders from the shipped styles.</span>
+    <span>Building with an AI agent? Point it at <a href="llms.txt"><code>llms.txt</code></a> — the full component API and rules in one markdown file.</span>
   </footer>
 
   <script src="ui/dist/ui.global.js"></script>

--- a/scripts/build-design-site.mjs
+++ b/scripts/build-design-site.mjs
@@ -10,9 +10,10 @@
  * Run `npm run build` in ui/ first (dist/browser must exist).
  */
 
-import { cp, mkdir, rm, access } from 'fs/promises';
+import { cp, mkdir, rm, access, readFile, writeFile } from 'fs/promises';
 
 const OUT = 'dist-design-site';
+const SITE = 'https://design.readysetcloud.io';
 
 try {
   await access('ui/dist/browser');
@@ -28,5 +29,22 @@ await cp('design-system', OUT, { recursive: true });
 await cp('ui/styles', `${OUT}/ui/styles`, { recursive: true });
 await cp('ui/assets', `${OUT}/ui/assets`, { recursive: true });
 await cp('ui/dist/browser', `${OUT}/ui/dist`, { recursive: true });
+
+// Publish the agent guide verbatim at /llms.txt (and /AGENTS.md) so LLMs can be
+// pointed at the site instead of the repo. Same no-drift rule as the pages: the
+// content IS ui/AGENTS.md, plus a short preface linking the machine-readable assets.
+const agentGuide = await readFile('ui/AGENTS.md', 'utf8');
+const llmsDoc = `<!--
+  Published from rsc-core/ui/AGENTS.md on every deploy — do not edit here.
+  Machine-readable companions on this site:
+    ${SITE}/ui/styles/tokens.css      every design token (color ramps + dark inversion, radii, shadows, fonts)
+    ${SITE}/ui/styles/components.css  the shipped component classes
+    ${SITE}/components.html           live gallery with paired React/HTML snippets
+    ${SITE}/patterns.html             dark mode, responsive contract, how each surface consumes the system
+-->
+
+${agentGuide}`;
+await writeFile(`${OUT}/llms.txt`, llmsDoc);
+await writeFile(`${OUT}/AGENTS.md`, llmsDoc);
 
 console.log(`Design-system guide assembled in ${OUT}/`);


### PR DESCRIPTION
## What changed

The design-system Pages build now publishes `ui/AGENTS.md` verbatim at `design.readysetcloud.io/llms.txt` (and `/AGENTS.md`), prefixed with a short comment linking the machine-readable companions on the site: `ui/styles/tokens.css`, `ui/styles/components.css`, and the gallery/patterns pages.

- `scripts/build-design-site.mjs` — reads `ui/AGENTS.md`, prepends the preface, writes both files into `dist-design-site/`
- All four guide pages — `<link rel="alternate" type="text/markdown" href="llms.txt">` in the head, plus a footer line pointing AI-agent users at it
- `design-system/README.md` — documents the setup

## Why

`ui/AGENTS.md` is the complete agent-facing API surface for `@readysetcloud/ui`, but it only existed inside rsc-core. Agents working in consumer repos (newsletter-service, concurrency-bootcamp, ready-set-cloud) — or Codex/Claude pointed at the design site — couldn't see it and had to scrape the HTML gallery instead. Now the incantation from any repo is: *"Read https://design.readysetcloud.io/llms.txt and follow it."*

## Notes for review

- Same no-drift rule as the rest of the site: there is no second doc to maintain. The deploy workflow already triggers on `ui/**`, so editing `ui/AGENTS.md` republishes `llms.txt` automatically.
- Verified locally: built `ui/`, ran `node scripts/build-design-site.mjs`, confirmed `dist-design-site/llms.txt` contains the preface + full guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)