### PR TITLE
feat(events): add a "Schedule Event" primitive for deferred events

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,61 @@ demos, and theming rules — is published to GitHub Pages from
 `ui/`, so the guide always reflects the shipped package. API details for
 consumers are in [`ui/AGENTS.md`](ui/AGENTS.md).
 
+## Deferred events — publish an event later
+
+Anything that can `events:PutEvents` on the default bus can also schedule an
+event for a future moment. Emit a `Schedule Event` request and
+`ScheduleEventFunction` creates a one-time, self-deleting EventBridge Scheduler
+schedule that publishes your event at that time. Callers need no Scheduler
+client, no IAM role of their own, and no time-zone math — a GitHub workflow, a
+Lambda, or a CLI one-liner all use the same PutEvents they already have.
+
+```json
+{
+  "Source": "<your-app>",
+  "DetailType": "Schedule Event",
+  "Detail": {
+    "at": "2026-07-27T09:00:00",       // when — ISO instant, or wall time + timezone
+    "timezone": "America/Chicago",     // optional, default UTC (ignored if `at` has an offset)
+    "delay": "15m",                    // alternative to `at` — 90s, 15m, 2h, 3d, 1h30m
+    "name": "newsletter-rebuild-220",  // optional idempotency key
+    "whenPast": "send",                // send (default) | skip | error
+    "event": {                         // what to publish when the moment arrives
+      "source": "<defaults to this request's source>",
+      "detailType": "Trigger Site Rebuild",
+      "detail": { "issueNumber": 220 }
+    }
+  }
+}
+```
+
+* **`at` vs `delay`** — one is required. `at` takes an absolute instant
+  (`2026-07-27T14:00:00Z`, or with a `±HH:MM` offset), a wall-clock time
+  interpreted in `timezone`, or a bare date, which means the start of that day
+  in `timezone`. DST is handled from the zone's rules for the target date.
+* **`name`** — re-emitting with the same name *moves* the pending schedule
+  instead of failing, so a re-run of your workflow is safe. Without one, every
+  request is its own schedule. Names are sanitized to Scheduler's
+  `[0-9a-zA-Z-_.]`, 64 characters.
+* **`whenPast`** — a moment that has already gone by defaults to publishing
+  immediately (the point is usually that the work happens, not that it waits).
+  `skip` drops it quietly; `error` logs and drops it.
+* **Cancel** — emit `Cancel Scheduled Event` with `{ "name": "..." }` to remove
+  a pending schedule. Cancelling one that already fired is a no-op.
+
+Malformed requests are logged and dropped rather than retried for 24 hours, so
+check the function's logs if a schedule you expected never appeared. Pending
+schedules are listed under the stack's `DeferredEventScheduleGroup`:
+
+```bash
+aws scheduler list-schedules --group-name <group-name>
+```
+
+Scheduling grants no authority beyond a delay — the schedule performs the same
+`PutEvents` on the same account-internal bus that the requester had to reach to
+get here, and the role Scheduler assumes can do nothing else. Scheduling a
+`Schedule Event` is rejected, since that only ever produces a loop.
+
 ## Badge Chest — cross-app gamification
 
 The badge chest is a single, ecosystem-wide trophy case. Because every app

--- a/functions/schedule-event.mjs
+++ b/functions/schedule-event.mjs
@@ -1,0 +1,294 @@
+import {
+  SchedulerClient,
+  CreateScheduleCommand,
+  UpdateScheduleCommand,
+  DeleteScheduleCommand
+} from '@aws-sdk/client-scheduler';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+
+const scheduler = new SchedulerClient();
+const eventBridge = new EventBridgeClient();
+
+const SCHEDULE_GROUP = process.env.SCHEDULE_GROUP;
+const SCHEDULER_ROLE_ARN = process.env.SCHEDULER_ROLE_ARN;
+const EVENT_BUS_ARN = process.env.EVENT_BUS_ARN;
+
+const SCHEDULE_DETAIL_TYPE = 'Schedule Event';
+const CANCEL_DETAIL_TYPE = 'Cancel Scheduled Event';
+
+/**
+ * "Publish this event later" as a bus primitive.
+ *
+ * Any app that can `events:PutEvents` on the default bus can hand off a future
+ * event — no Scheduler client, no IAM role of its own, no time-zone math in the
+ * caller. Emit `Schedule Event` with a when and the event to fire; this creates
+ * a one-time, self-deleting EventBridge Scheduler schedule that does the
+ * PutEvents at that moment.
+ *
+ *   {
+ *     "Source": "<your-app>",
+ *     "DetailType": "Schedule Event",
+ *     "Detail": {
+ *       "name": "newsletter-rebuild-220",   // optional idempotency key
+ *       "at": "2026-07-27T09:00:00",        // ISO instant, or naive + timezone
+ *       "timezone": "America/Chicago",      // optional, default UTC
+ *       "delay": "15m",                     // alternative to `at`
+ *       "whenPast": "send",                 // send (default) | skip | error
+ *       "event": {
+ *         "source": "<defaults to this event's source>",
+ *         "detailType": "Trigger Site Rebuild",
+ *         "detail": { "issueNumber": 220 }
+ *       }
+ *     }
+ *   }
+ *
+ * Re-emitting with the same `name` moves the existing schedule instead of
+ * failing, so a re-run of the caller's workflow is safe. `Cancel Scheduled
+ * Event` with `{ "name": "..." }` removes one before it fires.
+ *
+ * Trust: the schedule fires a PutEvents on the same account-internal bus the
+ * caller already had to reach to get here, so this grants no authority beyond a
+ * delay — the Scheduler role is scoped to that single action.
+ */
+export const handler = async (event) => {
+  const detail = event?.detail;
+  if (!detail) {
+    console.error('Schedule request has no detail; ignoring', { id: event?.id });
+    return;
+  }
+
+  try {
+    if (event['detail-type'] === CANCEL_DETAIL_TYPE) {
+      await cancel(detail);
+      return;
+    }
+
+    await schedule(detail, event);
+  } catch (err) {
+    // A malformed request never succeeds on retry, so it is logged and dropped
+    // rather than rethrown into EventBridge's 24-hour retry. Scheduler's own
+    // ValidationException (a time too far out, a name it still won't take) is
+    // the same class of problem, just caught one layer down.
+    if (err instanceof RequestError || err.name === 'ValidationException') {
+      console.error(err.message, { id: event?.id, detail });
+      return;
+    }
+
+    console.error('Failed to handle schedule request', { id: event?.id, err });
+    throw err;
+  }
+};
+
+class RequestError extends Error { }
+
+const cancel = async (detail) => {
+  const name = getScheduleName(detail);
+  if (!name) {
+    throw new RequestError('Cancel request must include the `name` of the schedule to remove');
+  }
+
+  try {
+    await scheduler.send(new DeleteScheduleCommand({ Name: name, GroupName: SCHEDULE_GROUP }));
+    console.log(`Cancelled scheduled event '${name}'`);
+  } catch (err) {
+    // Already fired (schedules self-delete) or already cancelled — either way
+    // the requested end state holds.
+    if (err.name === 'ResourceNotFoundException') {
+      console.log(`No schedule named '${name}' to cancel; nothing to do`);
+      return;
+    }
+
+    throw err;
+  }
+};
+
+const schedule = async (detail, event) => {
+  const target = getTargetEvent(detail, event);
+  const fireAt = getFireAt(detail);
+
+  if (fireAt.getTime() <= Date.now()) {
+    return handlePastTime(detail, target, fireAt);
+  }
+
+  const name = getScheduleName(detail) ?? `evt-${event.id}`;
+  const input = {
+    Name: name,
+    GroupName: SCHEDULE_GROUP,
+    // One-shot: Scheduler removes the schedule once it fires, so nothing
+    // accumulates and callers never have to clean up.
+    ActionAfterCompletion: 'DELETE',
+    FlexibleTimeWindow: { Mode: 'OFF' },
+    State: 'ENABLED',
+    Description: `${target.detailType} from ${target.source}${detail.timezone ? ` (requested for ${detail.timezone})` : ''}`,
+    // The instant is resolved here, so the expression is always in UTC — one
+    // frame of reference for both the past check above and Scheduler.
+    ScheduleExpression: `at(${fireAt.toISOString().slice(0, 19)})`,
+    ScheduleExpressionTimezone: 'UTC',
+    Target: {
+      Arn: EVENT_BUS_ARN,
+      RoleArn: SCHEDULER_ROLE_ARN,
+      EventBridgeParameters: {
+        Source: target.source,
+        DetailType: target.detailType
+      },
+      Input: JSON.stringify(target.detail)
+    }
+  };
+
+  try {
+    await scheduler.send(new CreateScheduleCommand(input));
+    console.log(`Scheduled '${target.detailType}' as '${name}' for ${fireAt.toISOString()}`);
+  } catch (err) {
+    // Same name again: a workflow re-run or a changed send time. Move the
+    // existing schedule rather than failing the caller.
+    if (err.name === 'ConflictException') {
+      await scheduler.send(new UpdateScheduleCommand(input));
+      console.log(`Moved '${name}' to ${fireAt.toISOString()}`);
+      return;
+    }
+
+    throw err;
+  }
+};
+
+const handlePastTime = async (detail, target, fireAt) => {
+  const whenPast = detail.whenPast ?? 'send';
+
+  if (whenPast === 'skip') {
+    console.log(`${fireAt.toISOString()} has passed; skipping '${target.detailType}' per whenPast=skip`);
+    return;
+  }
+
+  if (whenPast === 'error') {
+    throw new RequestError(`${fireAt.toISOString()} has already passed and whenPast=error`);
+  }
+
+  // Default: the moment being scheduled for is the point, so a request that
+  // arrives late still fires — dropping it silently loses the work.
+  console.log(`${fireAt.toISOString()} has passed; publishing '${target.detailType}' now`);
+  const response = await eventBridge.send(new PutEventsCommand({
+    Entries: [{
+      Source: target.source,
+      DetailType: target.detailType,
+      Detail: JSON.stringify(target.detail)
+    }]
+  }));
+
+  if (response.FailedEntryCount > 0) {
+    console.error(response.Entries);
+    throw new Error(`Failed to publish '${target.detailType}'`);
+  }
+};
+
+const getTargetEvent = (detail, event) => {
+  const target = detail.event ?? {};
+  const detailType = target.detailType ?? target['detail-type'];
+  if (!detailType) {
+    throw new RequestError('Schedule request must include `event.detailType`');
+  }
+
+  // Scheduling a schedule request is a loop that only shows up as a runaway
+  // bill, and the useful version of it (a chain longer than Scheduler allows)
+  // is better written explicitly.
+  if (detailType === SCHEDULE_DETAIL_TYPE) {
+    throw new RequestError(`Cannot schedule a '${SCHEDULE_DETAIL_TYPE}' event`);
+  }
+
+  return {
+    // Callers usually want the delayed event attributed to themselves, so the
+    // requesting event's source is the default.
+    source: target.source ?? event.source,
+    detailType,
+    detail: target.detail ?? {}
+  };
+};
+
+// Scheduler names allow [0-9a-zA-Z-_.] up to 64 characters.
+const getScheduleName = (detail) => {
+  if (!detail.name) {
+    return;
+  }
+
+  const name = `${detail.name}`.replace(/[^0-9a-zA-Z\-_.]/g, '-').slice(0, 64);
+  if (!name) {
+    throw new RequestError(`'${detail.name}' has no characters usable in a schedule name`);
+  }
+
+  return name;
+};
+
+const getFireAt = (detail) => {
+  if (detail.delay) {
+    return new Date(Date.now() + parseDelay(detail.delay));
+  }
+
+  if (!detail.at) {
+    throw new RequestError('Schedule request must include either `at` or `delay`');
+  }
+
+  const at = `${detail.at}`.trim();
+  // A bare date means the start of that day in the requested zone.
+  const stamp = /^\d{4}-\d{2}-\d{2}$/.test(at) ? `${at}T00:00:00` : at;
+
+  // An offset (`Z` or `±HH:MM`) already pins the instant; anything else is wall
+  // time in `timezone`.
+  const fireAt = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(stamp)
+    ? new Date(stamp)
+    : toInstant(stamp, detail.timezone ?? 'UTC');
+
+  if (isNaN(fireAt.getTime())) {
+    throw new RequestError(`'${detail.at}' is not a usable date/time`);
+  }
+
+  return fireAt;
+};
+
+// "90s" | "15m" | "2h" | "3d", or combined ("1h30m"). A bare number is seconds.
+const UNITS = { s: 1000, m: 60000, h: 3600000, d: 86400000 };
+const parseDelay = (delay) => {
+  const value = `${delay}`.trim().toLowerCase();
+  if (/^\d+$/.test(value)) {
+    return Number(value) * 1000;
+  }
+
+  const parts = value.match(/^(\d+[smhd])+$/) && [...value.matchAll(/(\d+)([smhd])/g)];
+  if (!parts?.length) {
+    throw new RequestError(`'${delay}' is not a usable delay (expected e.g. 90s, 15m, 2h, 3d)`);
+  }
+
+  return parts.reduce((total, [, amount, unit]) => total + Number(amount) * UNITS[unit], 0);
+};
+
+// Milliseconds a zone is ahead of UTC at a given instant, read out of Intl so
+// the zone's DST rules apply without a date library.
+const getZoneOffset = (instant, timeZone) => {
+  const offset = new Intl.DateTimeFormat('en-US', { timeZone, timeZoneName: 'longOffset' })
+    .formatToParts(instant)
+    .find(part => part.type === 'timeZoneName').value;
+
+  // Zones sitting exactly on UTC render as a bare "GMT" with no offset to parse.
+  const parts = offset.match(/GMT([+-])(\d{2}):(\d{2})/);
+  if (!parts) {
+    return 0;
+  }
+
+  const [, sign, hours, minutes] = parts;
+  return (sign === '-' ? -1 : 1) * (Number(hours) * 3600000 + Number(minutes) * 60000);
+};
+
+// The instant at which a wall-clock time happens in `timeZone`: guess UTC, then
+// correct by that zone's offset. The second pass settles the guess when the
+// first landed on the wrong side of a DST transition.
+const toInstant = (stamp, timeZone) => {
+  const utcGuess = new Date(`${stamp}Z`);
+  if (isNaN(utcGuess.getTime())) {
+    return utcGuess;
+  }
+
+  try {
+    const firstPass = new Date(utcGuess.getTime() - getZoneOffset(utcGuess, timeZone));
+    return new Date(utcGuess.getTime() - getZoneOffset(firstPass, timeZone));
+  } catch {
+    throw new RequestError(`'${timeZone}' is not a usable IANA time zone`);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@aws-sdk/client-eventbridge": "^3.1086.0",
         "@aws-sdk/client-lambda": "^3.1091.0",
         "@aws-sdk/client-s3": "^3.1091.0",
+        "@aws-sdk/client-scheduler": "^3.1095.0",
         "@aws-sdk/client-ssm": "^3.1091.0",
         "@aws-sdk/credential-providers": "^3.1091.0",
         "@aws-sdk/util-dynamodb": "^3.996.7",
@@ -187,6 +188,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1091.0.tgz",
       "integrity": "sha512-7NxnvP3pPAcUpSb9UxEKKSyppxfjvBV3MEoyFZ8NbxrAIMjCj0hUQxNbVBGTqvEf3hQBklf6ZlfE+WmGwczJRw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
         "@aws-sdk/credential-provider-node": "^3.972.70",
@@ -249,6 +251,7 @@
       "integrity": "sha512-jvXBCWZdPEXACF7TEbLdwLgmrcWvAqSnIJeRbnnFTxLuPRAZtEbujVUU48i7PGnrOoO6Jc6HCw9hRqBECoKSww==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.18",
         "@aws-sdk/core": "^3.975.3",
@@ -266,12 +269,33 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-scheduler": {
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-scheduler/-/client-scheduler-3.1095.0.tgz",
+      "integrity": "sha512-+Si5MlwZSkDprOuKQ54NrnN6n8pLeXH72HTGdva9L9RDpMgg3+oVzCWw6vEsk3gIjmb4x+zPCO7DEKlFSg8RHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm": {
       "version": "3.1091.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1091.0.tgz",
       "integrity": "sha512-aqDOBa+gA4nH77Gh18gHQzo7ZGEX5cY9y7YHTQ/rXukqC/+BJ2uIfjbQVbxKGhrfNYlLgdc/cDsvrYM/t83jaQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
         "@aws-sdk/credential-provider-node": "^3.972.70",
@@ -287,16 +311,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
-      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -323,14 +347,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
-      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
+      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -339,16 +363,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
-      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
+      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -357,22 +381,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
-      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
+      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.66",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-login": "^3.972.68",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -381,15 +405,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
-      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
+      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -398,20 +422,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
-      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
+      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.4",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-ini": "^3.973.6",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -420,14 +444,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
-      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
+      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -436,16 +460,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
-      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
+      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/token-providers": "3.1095.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -454,15 +478,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
-      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
+      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -628,17 +652,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
-      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "version": "3.997.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
+      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -647,13 +671,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -662,15 +686,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
-      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
+      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -696,6 +720,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
       "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -707,9 +732,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -726,29 +751,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -935,6 +937,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
       "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -966,7 +969,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1589,7 +1591,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1630,7 +1631,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1647,7 +1647,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1656,8 +1655,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1789,6 +1787,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2415,9 +2414,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
-      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2428,12 +2427,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
-      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2442,12 +2441,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
-      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2456,12 +2455,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
-      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2470,12 +2469,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
-      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2794,7 +2793,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2808,7 +2806,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2818,7 +2815,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2836,6 +2832,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2887,7 +2884,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2905,7 +2901,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2921,8 +2916,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3017,7 +3011,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -3091,7 +3084,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3114,7 +3106,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3185,7 +3176,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3219,7 +3209,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3229,7 +3218,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -3239,7 +3227,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -3313,7 +3300,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3346,8 +3332,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3360,7 +3345,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3430,8 +3414,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3452,6 +3435,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3629,7 +3613,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3639,7 +3622,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -3652,7 +3634,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -3716,7 +3697,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -3735,7 +3715,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3745,7 +3724,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3755,7 +3733,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3801,8 +3778,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3840,7 +3816,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -3936,7 +3911,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3946,7 +3920,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4051,7 +4024,8 @@
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
+      "license": "(BSD-3-Clause AND Apache-2.0)",
+      "peer": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -4119,7 +4093,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -4153,7 +4126,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4209,15 +4181,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4227,7 +4197,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -4268,8 +4237,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4282,7 +4250,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4305,8 +4272,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4664,7 +4630,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4674,7 +4639,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4765,7 +4729,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4775,7 +4738,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4785,7 +4747,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4840,7 +4801,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -4853,7 +4813,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4863,6 +4822,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
       "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
         "@smithy/hash-node": ">=4.3.0 <5",
@@ -4943,7 +4903,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4972,7 +4931,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -4998,6 +4956,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5010,7 +4969,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -5082,7 +5040,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -5115,7 +5072,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -5132,7 +5088,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       },
@@ -5146,7 +5101,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -5171,7 +5125,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5215,7 +5168,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -5231,8 +5183,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -5252,7 +5203,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -5279,7 +5229,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5289,7 +5238,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5306,7 +5254,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -5325,8 +5272,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -5404,7 +5350,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -5424,7 +5369,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -5441,7 +5385,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5460,7 +5403,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5504,7 +5446,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5600,7 +5541,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -5629,7 +5569,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -5648,7 +5587,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5658,7 +5596,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5708,7 +5645,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5741,7 +5677,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5752,6 +5687,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -5977,8 +5913,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6049,6 +5984,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6058,7 +5994,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -753,6 +753,29 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-eventbridge": "^3.1086.0",
     "@aws-sdk/client-lambda": "^3.1091.0",
     "@aws-sdk/client-s3": "^3.1091.0",
+    "@aws-sdk/client-scheduler": "^3.1095.0",
     "@aws-sdk/client-ssm": "^3.1091.0",
     "@aws-sdk/credential-providers": "^3.1091.0",
     "@aws-sdk/util-dynamodb": "^3.996.7",

--- a/template.yaml
+++ b/template.yaml
@@ -381,6 +381,94 @@ Resources:
                 - Send Email
 
   # ----------------------------------------------------------------------------
+  # Deferred events — "publish this event later" as a bus primitive.
+  #
+  # An app emits "Schedule Event" with a when and the event it wants fired, and
+  # ScheduleEventFunction creates a one-time, self-deleting EventBridge Scheduler
+  # schedule that publishes it at that moment. Callers need only events:PutEvents
+  # — no Scheduler client, no IAM role of their own, no time-zone math. See the
+  # handler and the README for the contract.
+  # ----------------------------------------------------------------------------
+
+  # Schedules live in their own group so the pending set is one console/CLI
+  # listing, separate from any schedule another stack creates.
+  DeferredEventScheduleGroup:
+    Type: AWS::Scheduler::ScheduleGroup
+
+  # Assumed by Scheduler when a schedule fires. Scoped to the single action every
+  # deferred event performs, so a schedule can never do more than the PutEvents
+  # its requester could already have done directly.
+  DeferredEventSchedulerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+      Policies:
+        - PolicyName: PublishDeferredEvent
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: events:PutEvents
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+
+  ScheduleEventFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - schedule-event.mjs
+    Properties:
+      Handler: schedule-event.handler
+      Timeout: 10
+      Environment:
+        Variables:
+          SCHEDULE_GROUP: !Ref DeferredEventScheduleGroup
+          SCHEDULER_ROLE_ARN: !GetAtt DeferredEventSchedulerRole.Arn
+          EVENT_BUS_ARN: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - scheduler:CreateSchedule
+                - scheduler:UpdateSchedule
+                - scheduler:DeleteSchedule
+              Resource: !Sub arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/${DeferredEventScheduleGroup}/*
+            # Handing the role above to Scheduler is what lets the schedule
+            # publish; the condition keeps it usable for nothing else.
+            - Effect: Allow
+              Action: iam:PassRole
+              Resource: !GetAtt DeferredEventSchedulerRole.Arn
+              Condition:
+                StringEquals:
+                  iam:PassedToService: scheduler.amazonaws.com
+            # The whenPast=send path publishes directly instead of scheduling a
+            # moment that has already gone by.
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+      Events:
+        ScheduleRequest:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              detail-type:
+                - Schedule Event
+                - Cancel Scheduled Event
+
+  # ----------------------------------------------------------------------------
   # Badge Chest — cross-app gamification (badges, points, levels)
   #
   # Apps emit "Track Activity" events to the default bus (or POST them to the


### PR DESCRIPTION
Publishing an event at a future moment currently means every caller builds it
themselves: a Scheduler client, an IAM role it has to create, conflict handling,
and its own time-zone math. The open PR in `readysetcloud/ready-set-cloud` is
~291 lines of exactly that, just to fire `Trigger Site Rebuild` at an issue's
send time.

This makes it a bus primitive. Anything that can already `events:PutEvents` on
the default bus emits a `Schedule Event` request with a *when* and the event it
wants fired; `ScheduleEventFunction` creates a one-time, self-deleting
EventBridge Scheduler schedule that publishes it at that moment.

```json
{
  "Source": "<your-app>",
  "DetailType": "Schedule Event",
  "Detail": {
    "at": "2026-07-27T09:00:00",
    "timezone": "America/Chicago",
    "name": "newsletter-rebuild-220",
    "event": { "detailType": "Trigger Site Rebuild", "detail": { "issueNumber": 220 } }
  }
}
```

## What's here

- **`functions/schedule-event.mjs`** — resolves the instant, creates the
  schedule with `ActionAfterCompletion: DELETE`, and handles the awkward cases
  so callers don't have to.
- **`template.yaml`** — the function, a `DeferredEventScheduleGroup` so the
  pending set is one listing, and the role Scheduler assumes.
- **`README.md`** — the contract and operational notes.

## The flexibility knobs

- **`at` / `delay`** — one is required. `at` takes an absolute instant
  (`...Z` or `±HH:MM`), a wall-clock time interpreted in `timezone`, or a bare
  date meaning the start of that day in `timezone`. `delay` is the relative form
  (`90s`, `2h`, `1h30m`). DST comes from the zone's rules for the target date.
- **`name`** — optional idempotency key. Re-emitting with the same name *moves*
  the pending schedule instead of failing, which is what a re-run of a caller's
  workflow needs. Sanitized to Scheduler's `[0-9a-zA-Z-_.]`, 64 chars.
- **`whenPast`** — a moment that already passed defaults to publishing
  immediately, since the point is usually that the work happens rather than that
  it waits. `skip` and `error` are the alternatives.
- **`event.source`** defaults to the requesting event's source.
- **`Cancel Scheduled Event`** with `{ "name": "..." }` removes a pending
  schedule; cancelling one that already fired is a no-op.

## Notes for review

- **Authority.** The schedule performs the same `PutEvents` on the same
  account-internal bus the requester had to reach to get here, so this grants
  nothing beyond a delay — the Scheduler role is scoped to that single action.
  The rule matches on `detail-type` alone, matching `Send Email` and
  `Trigger Site Rebuild`; if you'd rather gate it, adding a `source` allowlist to
  the rule pattern is a two-line change. Scheduling a `Schedule Event` is
  rejected, since that only ever produces a loop.
- **Retries.** Malformed requests — and Scheduler's own `ValidationException` —
  are logged and dropped rather than rethrown into EventBridge's 24-hour retry,
  since neither succeeds on a retry. Check the function's logs if an expected
  schedule never appears.
- **Verified locally:** zone resolution against both 2026 US DST transition days,
  half-hour offsets (Kolkata), bare-`GMT` zones (London in winter), explicit
  `Z`/offset passthrough, and the delay/error paths. `sam validate` passes and
  lint is clean; the two remaining `--lint` errors (`NamespaceTemplates`,
  `NODE_22`) are pre-existing on `AgentCoreRuntime` and untouched here.
- **Lockfile churn** — `@aws-sdk/client-scheduler` was added as a devDependency
  (the SDK clients are all `external` in the esbuild config, provided by the
  runtime), which re-resolved some transitive AWS SDK versions.

Once this deploys, the `ready-set-cloud` PR collapses to a single `PutEvents`
and no longer needs `iam:CreateRole`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
